### PR TITLE
Add Include Directory for library

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -3,7 +3,7 @@
 #
 
 DEPS = evdi_ioctl.h
-CFLAGS := -std=gnu99 -fPIC $(CFLAGS)
+CFLAGS := -I../module -std=gnu99 -fPIC $(CFLAGS)
 
 default: libevdi.so
 


### PR DESCRIPTION
The Makefile for the library does not contain an Include Directory. Thus, you cannot make the library on its own, which is bad when creating packages for distributions.

```
library $ make
cc -std=gnu99 -fPIC    -c -o evdi_lib.o evdi_lib.c
evdi_lib.c:8:22: fatal error: evdi_drm.h: No such file or directory
 #include "evdi_drm.h"
                      ^
compilation terminated.
<builtin>: recipe for target 'evdi_lib.o' failed
```

With this pull request you can just "make" the library:

```
library $ make
cc -I../module -std=gnu99 -fPIC    -c -o evdi_lib.o evdi_lib.c
cc evdi_lib.o -o libevdi.so -lc -lgcc -shared
```

This is already changed in the Makefile in the main directory as it containts:

```
CFLAGS="-I../module $(CFLAGS)" $(MAKE) -C library $(MFLAGS)
```