### PR TITLE
Fix version checks for 4.7.x kernels

### DIFF
--- a/module/evdi_cursor.c
+++ b/module/evdi_cursor.c
@@ -92,7 +92,7 @@ int evdi_cursor_set(__maybe_unused struct drm_crtc *crtc, struct drm_file *file,
 					EVDI_CURSOR_W, EVDI_CURSOR_H);
 			return -EINVAL;
 		}
-		#if KERNEL_VERSION(4, 6, 0) >= LINUX_VERSION_CODE
+		#if KERNEL_VERSION(4, 7, 0) > LINUX_VERSION_CODE
 			obj = drm_gem_object_lookup(crtc->dev, file, handle);
 		#else
 			obj = drm_gem_object_lookup(file, handle);

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -500,7 +500,7 @@ struct drm_framebuffer *evdi_fb_user_fb_create(
 		return ERR_PTR(-EINVAL);
 	}
 
-	#if KERNEL_VERSION(4, 6, 0) >= LINUX_VERSION_CODE
+	#if KERNEL_VERSION(4, 7, 0) > LINUX_VERSION_CODE
 		obj = drm_gem_object_lookup(dev, file, mode_cmd->handles[0]);
 	#else
 		obj = drm_gem_object_lookup(file, mode_cmd->handles[0]);

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -208,7 +208,7 @@ int evdi_gem_mmap(struct drm_file *file,
 	int ret = 0;
 
 	mutex_lock(&dev->struct_mutex);
-	#if KERNEL_VERSION(4, 6, 0) >= LINUX_VERSION_CODE
+	#if KERNEL_VERSION(4, 7, 0) > LINUX_VERSION_CODE
 		obj = drm_gem_object_lookup(dev, file, handle);
 	#else
 		obj = drm_gem_object_lookup(file, handle);

--- a/module/evdi_main.c
+++ b/module/evdi_main.c
@@ -79,7 +79,7 @@ int evdi_driver_unload(struct drm_device *dev)
 
 	drm_vblank_cleanup(dev);
 	drm_kms_helper_poll_fini(dev);
-	#if KERNEL_VERSION(4, 6, 0) >= LINUX_VERSION_CODE
+	#if KERNEL_VERSION(4, 7, 0) > LINUX_VERSION_CODE
 		drm_connector_unplug_all(dev);
 	#else
 		drm_connector_unregister_all(dev);


### PR DESCRIPTION
Checking for "4.6.0 or less" when trying to determine when to use 4.7.x
series features does the wrong thing when running a 4.6 kernel when it
isn't the first release; a version of 4.6.4 will cause the selection of
4.7.x features, which will proceed to fail to build because the kernel
is a 4.6.x series. Fix the condition so that the right thing happens
with later 4.6.x series kernels.