### PR TITLE
Fix missing struct initializers reported by clang

### DIFF
--- a/library/evdi_lib.c
+++ b/library/evdi_lib.c
@@ -304,13 +304,13 @@ void evdi_connect(evdi_handle handle, const unsigned char* edid, const unsigned 
 
 void evdi_disconnect(evdi_handle handle)
 {
-  struct drm_evdi_connect cmd = { 0 };
+  struct drm_evdi_connect cmd = { 0, 0, 0, 0 };
   do_ioctl(handle->fd, DRM_IOCTL_EVDI_CONNECT, &cmd, "disconnect");
 }
 
 void evdi_grab_pixels(evdi_handle handle, evdi_rect *rects, int *num_rects)
 {
-  struct drm_clip_rect kernelDirts[MAX_DIRTS] = { { 0 } };
+  struct drm_clip_rect kernelDirts[MAX_DIRTS] = { { 0, 0, 0, 0 } };
   evdi_frame_buffer_node* destinationNode = NULL;
   evdi_buffer* destinationBuffer = NULL;
 


### PR DESCRIPTION
Clang wants all members of a struct to be initialized. It issues the
following warnings on the code, before the fix

evdi_lib.c:307:37: error: missing field 'dev_index' initializer
      [-Werror,-Wmissing-field-initializers]
        struct drm_evdi_connect cmd = { 0 };
                                            ^
evdi_lib.c:313:55: error: missing field 'y1' initializer
[-Werror,-Wmissing-field-initializers]
        struct drm_clip_rect kernelDirts[MAX_DIRTS] = { { 0 } };
                                                               ^