### PR TITLE
Changes errorneous number of elements.

### DIFF
--- a/library/evdi_lib.c
+++ b/library/evdi_lib.c
@@ -275,7 +275,7 @@ int evdi_add_device()
   if (add_devices != NULL) {
     const char devices_to_add[] = "1";
     const size_t elem_bytes = 1;
-    written = fwrite(devices_to_add, elem_bytes, sizeof(devices_to_add), add_devices);
+    written = fwrite(devices_to_add, elem_bytes, sizeof(char), add_devices);
     fclose(add_devices);
   }
 


### PR DESCRIPTION
In `evdi_add_device` one char (with the size of one byte) should be written. Before, `sizeof(devices_to_add)`, which is 2, were tried to be written.

I hope that I get the desired semantic right.