### PR TITLE
CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 
-language: cpp
+language: c
 
 env:
   - KVER=3.16
@@ -18,6 +18,7 @@ env:
   - KVER=4.8
   - KVER=4.9
   - KVER=4.10
+  - KVER=4.11
   - KVER=master
 
 matrix:

--- a/ci/build_against_kernel
+++ b/ci/build_against_kernel
@@ -42,7 +42,6 @@ prepare_kernel() { # srcDir
   make olddefconfig
   make prepare
   make scripts
-  make kernel
 
   cd "${oldDir}"
 }


### PR DESCRIPTION
This tests against v4.11, switches the Travis builds from C++ to C, and also speeds up the process by not building the kernel each time.