### PR TITLE
Fix return value of evdi_mode_valid

### DIFF
--- a/module/evdi_connector.c
+++ b/module/evdi_connector.c
@@ -45,7 +45,7 @@ static int evdi_get_modes(struct drm_connector *connector)
 	return ret;
 }
 
-static int evdi_mode_valid(struct drm_connector *connector,
+static enum drm_mode_status evdi_mode_valid(struct drm_connector *connector,
 			   struct drm_display_mode *mode)
 {
 	struct evdi_device *evdi = connector->dev->dev_private;


### PR DESCRIPTION
Since this commit:

commit 0993f1d0d8a1b516df4a059605af9979049d0187
Author: Damien Lespiau <damien.lespiau@intel.com>
Date:   Thu Nov 28 15:29:17 2013 +0000

    drm: Make the connector mode_valid() vfunc return a drm_mode_status enum
    
    To make it clear what exactly mode_valid() should return.
    
    Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>
    Signed-off-by: Daniel Vetter <daniel.vetter@ffwll.ch>


upstream has returned enum drm_mode_status instead of int.  Functionally it shouldn't change anything as you're already returning stuff from that enum, and those enum values go back to at least 2008, so it should be a perfectly compatible change to make.  

This patch comes from the grsecurity project, and it will fix compatibility with RAP and other fine-grained kernel CFI methods.