### PR TITLE
Various build fixups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 #
 
 FLAGS=-Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes
+PREFIX?=/usr/local
+VERSION=1.4.1
 
 all: module library
 
@@ -16,3 +18,5 @@ clean:
 	$(MAKE) clean -C module $(MFLAGS)
 	$(MAKE) clean -C library $(MFLAGS)
 
+install:
+	VERSION=$(VERSION) $(MAKE) -C library install

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@
 
 FLAGS=-Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes
 
-all:
+all: module library
+
+module:
 	CFLAGS="$(FLAGS)" $(MAKE) -C module $(MFLAGS)
+
+library:
 	CFLAGS="-I../module $(FLAGS) $(CFLAGS)" $(MAKE) -C library $(MFLAGS)
 
 clean:

--- a/library/Makefile
+++ b/library/Makefile
@@ -4,6 +4,7 @@
 
 DEPS = evdi_ioctl.h
 CFLAGS := -I../module -std=gnu99 -fPIC $(CFLAGS)
+LDFLAGS := -Wl,-soname,libevdi.so.0 $(LDFLAGS)
 
 default: libevdi.so
 
@@ -14,7 +15,7 @@ clean:
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 libevdi.so: evdi_lib.o
-	$(CC) $^ -o $@ -lc -lgcc -shared -Wl,-soname,libevdi.so.0
+	$(CC) $^ -o $@ -lc -lgcc -shared $(LDFLAGS)
 
 install: libevdi.so evdi_lib.h
 	mkdir -p $(PREFIX)/include $(PREFIX)/lib

--- a/library/Makefile
+++ b/library/Makefile
@@ -16,3 +16,9 @@ clean:
 libevdi.so: evdi_lib.o
 	$(CC) $^ -o $@ -lc -lgcc -shared -Wl,-soname,libevdi.so.0
 
+install: libevdi.so evdi_lib.h
+	mkdir -p $(PREFIX)/include $(PREFIX)/lib
+	install -m 0644 -D evdi_lib.h $(PREFIX)/include/evdi_lib.h
+	install -m 0644 -D libevdi.so $(PREFIX)/lib/libevdi.so.0.$(VERSION)
+	ln -s libevdi.so.0.$(VERSION) $(PREFIX)/lib/libevdi.so.0
+	ln -s libevdi.so.0.$(VERSION) $(PREFIX)/lib/libevdi.so

--- a/module/dkms.conf
+++ b/module/dkms.conf
@@ -7,7 +7,7 @@
 #
 
 PACKAGE_NAME="evdi"
-PACKAGE_VERSION=1.0.0
+PACKAGE_VERSION=1.4.1
 AUTOINSTALL=yes
 
 MAKE[0]="make all INCLUDEDIR=/lib/modules/$kernelver/build/include KVERSION=$kernelver DKMS_BUILD=1"


### PR DESCRIPTION
Here are handful of simple fixups for building:
- correct version number in dkms.conf
- break up the module and library builds
- respect LDFLAGS when linking
- add a target that installs the library