### PR TITLE
Linux kernel compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
   - KVER=4.9
   - KVER=4.10
   - KVER=4.11
+  - KVER=4.12
+  - KVER=4.13
   - KVER=master
 
 matrix:

--- a/module/evdi_drv.c
+++ b/module/evdi_drv.c
@@ -166,7 +166,11 @@ static int evdi_platform_remove(struct platform_device *pdev)
 	    (struct drm_device *)platform_get_drvdata(pdev);
 	EVDI_CHECKPT();
 
+#if KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE
+	drm_dev_unplug(drm_dev);
+#else
 	drm_unplug_dev(drm_dev);
+#endif
 
 	return 0;
 }

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -151,7 +151,11 @@ static int evdi_gem_get_pages(struct evdi_gem_object *obj,
 static void evdi_gem_put_pages(struct evdi_gem_object *obj)
 {
 	if (obj->base.import_attach) {
-		drm_free_large(obj->pages);
+#if KERNEL_VERSION(4, 13, 0) <= LINUX_VERSION_CODE
+		kvfree(obj->pages);
+#else
+        drm_free_large(obj->pages);
+#endif
 		obj->pages = NULL;
 		return;
 	}
@@ -273,7 +277,11 @@ static int evdi_prime_create(struct drm_device *dev,
 		return -ENOMEM;
 
 	obj->sg = sg;
-	obj->pages = drm_malloc_ab(npages, sizeof(struct page *));
+#if KERNEL_VERSION(4, 13, 0) <= LINUX_VERSION_CODE
+	obj->pages = kvmalloc_array(npages, sizeof(struct page *), GFP_KERNEL);
+#else
+    obj->pages = drm_malloc_ab(npages, sizeof(struct page *));
+#endif
 	if (obj->pages == NULL) {
 		DRM_ERROR("obj pages is NULL %d\n", npages);
 		return -ENOMEM;


### PR DESCRIPTION
First commit: drm_dev_unplug change fixes building with linux master but is not triggered as master's version is still 4.13, so it still fails on travis.
Second commit is based on [daxtens work](https://github.com/daxtens/linux/commit/d5d500c295c151a939c54d0fe1800097b2ee05e1) and fixes building against kernel 4.13
Third commit enables kerenls 4.12 and 4.13 building on travis