### PR TITLE
added KERNELRELEASE variable to CLEAN in dkms.conf

### DIFF
--- a/module/dkms.conf
+++ b/module/dkms.conf
@@ -13,5 +13,5 @@ AUTOINSTALL=yes
 MAKE[0]="make all INCLUDEDIR=/lib/modules/$kernelver/build/include KVERSION=$kernelver DKMS_BUILD=1"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/gpu/drm/evdi"
 BUILT_MODULE_NAME[0]="evdi"
-CLEAN="make clean DKMS_BUILD=1"
+CLEAN="make clean KERNELRELEASE=$kernelver DKMS_BUILD=1"
 


### PR DESCRIPTION
`KERNELRELEASE` is automatically appended only to `MAKE` command, but not `CLEAN`, see http://manpages.ubuntu.com/manpages/trusty/man8/dkms.8.html .

At last on Fedora 27, the result is as follows:
```
Building module:
make clean KVERSION=4.14.16-300.fc27.x86_64 DKMS_BUILD=1
/lib/modules//build
make KBUILD_VERBOSE=1 SUBDIRS=/var/lib/dkms/evdi/1.0.0/build SRCROOT=/var/lib/dkms/evdi/1.0.0/build -C /lib/modules//build clean
make[1]: *** /lib/modules//build: No such file or directory.  Stop.
make: *** [Makefile:26: clean] Error 2
(bad exit status: 2)
(...)
```
Resulting in non-zero exit code of dkms command.
