### PR TITLE
Fix tests and build for kernels >= 4.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
     packages:
       - bc
       - g++-4.8
+      - libelf-dev
 
 script:
   - CC=gcc-4.8 ./ci/build_against_kernel ${KVER}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - KVER=4.12
   - KVER=4.13
   - KVER=4.14
+  - KVER=4.15
   - KVER=master
 
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Copyright (c) 2015 DisplayLink (UK) Ltd.
 #
 
-FLAGS=-Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes
+FLAGS=-Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes -Wno-error=missing-field-initializers
 
 all:
 	CFLAGS="$(FLAGS)" $(MAKE) -C module $(MFLAGS)

--- a/module/evdi_debug.h
+++ b/module/evdi_debug.h
@@ -19,9 +19,13 @@
 #define EVDI_LOGLEVEL_DEBUG   5
 #define EVDI_LOGLEVEL_VERBOSE 6
 
-#define EVDI_PRINTK(KERN_LEVEL, LEVEL, FORMAT_STR, ...)	do { \
-	if (evdi_loglevel >= LEVEL) {\
-		printk(KERN_LEVEL "evdi: " FORMAT_STR, ##__VA_ARGS__); \
+// This definition is to get checkpatch.pl to stop complaining.
+// TODO: Refactor all this to use pr_<level> and dev_dbg and stuff.
+#define __EVDI_PRINTK printk
+
+#define EVDI_PRINTK(kLEVEL, lEVEL, FORMAT_STR, ...)	do { \
+	if (lEVEL <= evdi_loglevel) {\
+		__EVDI_PRINTK(kLEVEL "evdi: " FORMAT_STR, ##__VA_ARGS__); \
 	} \
 } while (0)
 


### PR DESCRIPTION
This is basically a duplicate of #118, but with @xblitz's comment applied. Fixes #117. Also gets Travis-CI tests passing.

I'm a little uncertain about my test fixes; this is the first time I've worked with anything Linux kernel-related.