### PR TITLE
Ignore master kernel version faiures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
   - KVER=master
 
 matrix:
+  allow_failures:
+    - env: KVER=master
   include:
     - env: StyleCheck
       script: ./ci/run_style_check


### PR DESCRIPTION
Testing with the current development version of the linux kernel should cause unexpected errors and to have compatibility issues before it's released in the wild.
It's interesting to build with it, but it shouldn't make the builds break.