### PR TITLE
Use ccache for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 
 language: c
+cache: ccache
 
 env:
   - KVER=3.16


### PR DESCRIPTION
ccache is a compiler cache. It speeds up recompilation by caching previous compilations and detecting when the same compilation is being done again.
Travis supports caching compilation of C/C++/Obj C projects using ccache.
This PR enables that cache.