### PR TITLE
Remove use of FBINFO_CAN_FORCE_OUTPUT

### DIFF
--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -367,7 +367,7 @@ static int evdifb_create(struct drm_fb_helper *helper,
 	info->fix.smem_len = size;
 	info->fix.smem_start = (unsigned long)ufbdev->ufb.obj->vmapping;
 
-	info->flags = FBINFO_DEFAULT | FBINFO_CAN_FORCE_OUTPUT;
+	info->flags = FBINFO_DEFAULT;
 	info->fbops = &evdifb_ops;
 #if KERNEL_VERSION(4, 11, 0) > LINUX_VERSION_CODE
 	drm_fb_helper_fill_fix(info, fb->pitches[0], fb->depth);


### PR DESCRIPTION
The flag was removed in 4.20, see https://patchwork.kernel.org/patch/10572741/