### PR TITLE
Prevent IOMMU domain allocation failure

### DIFF
--- a/module/evdi_drv.c
+++ b/module/evdi_drv.c
@@ -174,6 +174,12 @@ static int evdi_platform_probe(struct platform_device *pdev)
 
 	EVDI_CHECKPT();
 
+	/* Intel-IOMMU workaround: platform-bus unsupported, force ID-mapping */
+#if IS_ENABLED(CONFIG_IOMMU_API) && defined(CONFIG_INTEL_IOMMU)
+#define INTEL_IOMMU_DUMMY_DOMAIN                ((void *)-1)
+	pdev->dev.archdata.iommu = INTEL_IOMMU_DUMMY_DOMAIN;
+#endif
+
 	dev = drm_dev_alloc(&driver, &pdev->dev);
 	if (IS_ERR(dev))
 		return PTR_ERR(dev);


### PR DESCRIPTION
Patch to prevent DMAR domain allocation failure copied from https://patchwork.kernel.org/patch/10778139/

Tested and working on Intel i7, Gentoo, kernel 4.19.23, xorg-server-1.20.4