### PR TITLE
Use FB offsets

### DIFF
--- a/module/evdi_cursor.c
+++ b/module/evdi_cursor.c
@@ -239,7 +239,7 @@ int evdi_cursor_compose_and_copy(struct evdi_cursor *cursor,
 			cursor_pix = h_cursor_w+x +
 				    (h_cursor_h+y)*cursor->width;
 			curs_val = le32_to_cpu(cursor_buffer[cursor_pix]);
-			fbsrc = (int *)efb->obj->vmapping;
+			fbsrc = (int *)(efb->obj->vmapping + fb->offsets[0]);
 			fb_value = *(fbsrc + ((fb->pitches[0]>>2) *
 						  mouse_pix_y + mouse_pix_x));
 			cmd_offset = (buf_byte_stride * mouse_pix_y) +

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -611,13 +611,13 @@ struct drm_framebuffer *evdi_fb_user_fb_create(
 	if (obj == NULL)
 		return ERR_PTR(-ENOENT);
 
-	size = mode_cmd->pitches[0] * mode_cmd->height;
+	size = mode_cmd->offsets[0] + mode_cmd->pitches[0] * mode_cmd->height;
 	size = ALIGN(size, PAGE_SIZE);
 
 	if (size > obj->size) {
-		DRM_ERROR("object size not sufficient for fb %d %zu %d %d\n",
-			  size, obj->size, mode_cmd->pitches[0],
-			  mode_cmd->height);
+		DRM_ERROR("object size not sufficient for fb %d %zu %u %d %d\n",
+			  size, obj->size, mode_cmd->offsets[0],
+			  mode_cmd->pitches[0], mode_cmd->height);
 		goto err_no_mem;
 	}
 

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -149,7 +149,8 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 	for (r = rects; r != rects + num_rects; ++r) {
 		const int byte_offset = r->x1 * 4;
 		const int byte_span = (r->x2 - r->x1) * 4;
-		const int src_offset = fb->pitches[0] * r->y1 + byte_offset;
+		const int src_offset = fb->offsets[0] +
+				       fb->pitches[0] * r->y1 + byte_offset;
 		const char *src = (char *)efb->obj->vmapping + src_offset;
 		const int dst_offset = buf_byte_stride * r->y1 + byte_offset;
 		char __user *dst = buffer + dst_offset;


### PR DESCRIPTION
When userspace calls add_fb2 ioctl, part of that is the offsets array. EVDI has
been assuming that the offsets are zero by not using them at all. If userspace
uses non-zero offset, that leads to incorrect buffer contents beings accessed.

Honour the offsets set by userspace. Only offsets[0] is used, because EVDI does
not support multi-plane formats.
