### PR TITLE
Added support for EL8.1+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@
 
 FLAGS=-Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes -Wno-error=missing-field-initializers
 
+EL8 := $(shell cat /etc/redhat-release | grep -c " 8." )
+ifneq (,$(findstring 1, $(EL8)))
+FLAGS:=$(FLAGS) -D EL8
+endif
+
 all:
 	CFLAGS="$(FLAGS)" $(MAKE) -C module $(MFLAGS)
 	CFLAGS="-I../module $(FLAGS) $(CFLAGS)" $(MAKE) -C library $(MFLAGS)

--- a/module/evdi_connector.c
+++ b/module/evdi_connector.c
@@ -18,7 +18,7 @@
 #include <drm/drm_atomic_helper.h>
 #include "evdi_drv.h"
 
-#if KERNEL_VERSION(5, 1, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 1, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <drm/drm_probe_helper.h>
 #endif
 
@@ -36,7 +36,7 @@ static int evdi_get_modes(struct drm_connector *connector)
 	edid = (struct edid *)evdi_painter_get_edid_copy(evdi);
 
 	if (!edid) {
-#if KERNEL_VERSION(4, 19, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(4, 19, 0) <= LINUX_VERSION_CODE || defined(EL8)
 		drm_connector_update_edid_property(connector, NULL);
 #else
 		drm_mode_connector_update_edid_property(connector, NULL);
@@ -44,7 +44,7 @@ static int evdi_get_modes(struct drm_connector *connector)
 		return 0;
 	}
 
-#if KERNEL_VERSION(4, 19, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(4, 19, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	ret = drm_connector_update_edid_property(connector, edid);
 #else
 	ret = drm_mode_connector_update_edid_property(connector, edid);
@@ -151,7 +151,7 @@ int evdi_connector_init(struct drm_device *dev, struct drm_encoder *encoder)
 
 	drm_connector_register(connector);
 
-#if KERNEL_VERSION(4, 19, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(4, 19, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	drm_connector_attach_encoder(connector, encoder);
 #else
 	drm_mode_connector_attach_encoder(connector, encoder);

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -410,7 +410,7 @@ static int evdifb_create(struct drm_fb_helper *helper,
 	info->fix.smem_len = size;
 	info->fix.smem_start = (unsigned long)efbdev->efb.obj->vmapping;
 
-#if KERNEL_VERSION(4, 20, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(4, 20, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	info->flags = FBINFO_DEFAULT;
 #else
 	info->flags = FBINFO_DEFAULT | FBINFO_CAN_FORCE_OUTPUT;
@@ -419,7 +419,7 @@ static int evdifb_create(struct drm_fb_helper *helper,
 	efbdev->fb_ops = evdifb_ops;
 	info->fbops = &efbdev->fb_ops;
 
-#if KERNEL_VERSION(5, 2, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 2, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	drm_fb_helper_fill_info(info, &efbdev->helper, sizes);
 #else
 	drm_fb_helper_fill_fix(info, fb->pitches[0], fb->format->depth);

--- a/module/evdi_ioc32.c
+++ b/module/evdi_ioc32.c
@@ -60,7 +60,7 @@ static int compat_evdi_connect(struct file *file,
 		return -EFAULT;
 
 	request = compat_alloc_user_space(sizeof(*request));
-#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	if (!access_ok(request, sizeof(*request))
 #else
 	if (!access_ok(VERIFY_WRITE, request, sizeof(*request))
@@ -88,7 +88,7 @@ static int compat_evdi_grabpix(struct file *file,
 		return -EFAULT;
 
 	request = compat_alloc_user_space(sizeof(*request));
-#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	if (!access_ok(request, sizeof(*request))
 #else
 	if (!access_ok(VERIFY_WRITE, request, sizeof(*request))

--- a/module/evdi_main.c
+++ b/module/evdi_main.c
@@ -20,7 +20,7 @@
 #include "evdi_drv.h"
 #include "evdi_cursor.h"
 
-#if KERNEL_VERSION(5, 1, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 1, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <drm/drm_probe_helper.h>
 #endif
 

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -24,7 +24,7 @@
 
 #include <linux/dma-buf.h>
 
-#if KERNEL_VERSION(5, 1, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 1, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <drm/drm_probe_helper.h>
 #endif
 


### PR DESCRIPTION
Added an additional flag EL8.1 which handles the logic for Enterprise Linux versions from 8.1 onward. 8.0 does not require this flag.