### PR TITLE
include CI builds for linux 5.7 and 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   - KVER=5.4
   - KVER=5.5
   - KVER=5.6
+  - KVER=5.7
+  - KVER=5.8
   - KVER=master
 
 matrix:


### PR DESCRIPTION
Since there are some issues with linux 5.8 and the current version of EVDI, it seems appropriate to include the latest kernels to CI
