### PR TITLE
v1.7.0 cherry-pick abucodonosor's fix: Adjust to kernel 5.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
   - KVER=5.4
   - KVER=5.5
   - KVER=5.6
+  - KVER=5.7
+  - KVER=5.8
+  - KVER=5.9
   - KVER=master
 
 matrix:

--- a/module/evdi_cursor.c
+++ b/module/evdi_cursor.c
@@ -55,7 +55,11 @@ static void evdi_cursor_set_gem(struct evdi_cursor *cursor,
 	if (obj)
 		drm_gem_object_get(&obj->base);
 	if (cursor->obj)
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+		drm_gem_object_put(&cursor->obj->base);
+#else
 		drm_gem_object_put_unlocked(&cursor->obj->base);
+#endif
 
 	cursor->obj = obj;
 }

--- a/module/evdi_drv.c
+++ b/module/evdi_drv.c
@@ -16,6 +16,9 @@
 #include <drm/drm_crtc_helper.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#include <linux/iommu.h>
+#endif
 
 #include "evdi_drv.h"
 #include "evdi_drm.h"
@@ -89,7 +92,11 @@ static struct drm_driver driver = {
 	.postclose = evdi_driver_postclose,
 
 	/* gem hooks */
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+	.gem_free_object_unlocked = evdi_gem_free_object,
+#else
 	.gem_free_object = evdi_gem_free_object,
+#endif
 	.gem_vm_ops = &evdi_gem_vm_ops,
 
 	.dumb_create = evdi_dumb_create,
@@ -164,13 +171,23 @@ static int evdi_platform_probe(struct platform_device *pdev)
 {
 	struct drm_device *dev;
 	int ret;
-
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if IS_ENABLED(CONFIG_IOMMU_API) && defined(CONFIG_INTEL_IOMMU)
+	struct dev_iommu iommu;
+#endif
+#endif
 	EVDI_CHECKPT();
 
-	/* Intel-IOMMU workaround: platform-bus unsupported, force ID-mapping */
+/* Intel-IOMMU workaround: platform-bus unsupported, force ID-mapping */
 #if IS_ENABLED(CONFIG_IOMMU_API) && defined(CONFIG_INTEL_IOMMU)
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+	memset(&iommu, 0, sizeof(iommu));
+	iommu.priv = (void *)-1;
+	pdev->dev.iommu = &iommu;
+#else
 #define INTEL_IOMMU_DUMMY_DOMAIN                ((void *)-1)
 	pdev->dev.archdata.iommu = INTEL_IOMMU_DUMMY_DOMAIN;
+#endif
 #endif
 
 	dev = drm_dev_alloc(&driver, &pdev->dev);

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -319,8 +319,11 @@ static void evdi_user_framebuffer_destroy(struct drm_framebuffer *fb)
 
 	EVDI_CHECKPT();
 	if (efb->obj)
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+		drm_gem_object_put(&efb->obj->base);
+#else
 		drm_gem_object_put_unlocked(&efb->obj->base);
-
+#endif
 	drm_framebuffer_cleanup(fb);
 	kfree(efb);
 }
@@ -438,7 +441,11 @@ static int evdifb_create(struct drm_fb_helper *helper,
 
 	return ret;
  out_gfree:
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+	drm_gem_object_put(&efbdev->efb.obj->base);
+#else
 	drm_gem_object_put_unlocked(&efbdev->efb.obj->base);
+#endif
  out:
 	return ret;
 }
@@ -464,7 +471,11 @@ static void evdi_fbdev_destroy(__always_unused struct drm_device *dev,
 	if (efbdev->efb.obj) {
 		drm_framebuffer_unregister_private(&efbdev->efb.base);
 		drm_framebuffer_cleanup(&efbdev->efb.base);
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+		drm_gem_object_put(&efbdev->efb.obj->base);
+#else
 		drm_gem_object_put_unlocked(&efbdev->efb.obj->base);
+#endif
 	}
 }
 

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -81,8 +81,11 @@ evdi_gem_create(struct drm_file *file,
 		kfree(obj);
 		return ret;
 	}
-
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+	drm_gem_object_put(&obj->base);
+#else
 	drm_gem_object_put_unlocked(&obj->base);
+#endif
 	*handle_p = handle;
 	return 0;
 }

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -129,8 +129,11 @@ static int evdi_crtc_cursor_set(struct drm_crtc *crtc,
 	evdi_cursor_set(evdi->cursor,
 			eobj, width, height, hot_x, hot_y,
 			format, stride);
-
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+	drm_gem_object_put(obj);
+#else
 	drm_gem_object_put_unlocked(obj);
+#endif
 
 	/*
 	 * For now we don't care whether the application wanted the mouse set,


### PR DESCRIPTION
Cherry picked https://github.com/DisplayLink/evdi/pull/227 for v1.7.0

Which is the branch we use on https://aur.archlinux.org/packages/displaylink/

Thank you @abucodonosor !