### PR TITLE
Use CI scripts from the latest supported kernel version

### DIFF
--- a/ci/run_style_check
+++ b/ci/run_style_check
@@ -10,8 +10,10 @@ files=(
   spelling.txt
 )
 
+KVER="v$(grep --only-matching --perl-regexp 'KVER=\K[\d\.]*' .travis.yml | tail -n 1)"
+
 for file in ${files[@]}; do
-  wget -N -q "https://raw.githubusercontent.com/torvalds/linux/master/scripts/${file}"
+  wget -N -q "https://raw.githubusercontent.com/torvalds/linux/${KVER}/scripts/${file}"
 done
 
 chmod +x checkpatch.pl


### PR DESCRIPTION
Closes #231 

### Summary
Download the scripts run in `ci/run_style_check` from the latest supported kernel version instead of the mainline tree.

