### PR TITLE
Added support for 5.10 by applying @abucodonosor's patch found in #234.

### DIFF
--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -305,7 +305,10 @@ evdi_prime_import_sg_table(struct drm_device *dev,
 struct sg_table *evdi_prime_get_sg_table(struct drm_gem_object *obj)
 {
 	struct evdi_gem_object *bo = to_evdi_bo(obj);
-
-	return drm_prime_pages_to_sg(bo->pages, bo->base.size >> PAGE_SHIFT);
+	#if KERNEL_VERSION(5, 10, 0) <= LINUX_VERSION_CODE
+		return drm_prime_pages_to_sg(obj->dev, bo->pages, bo->base.size >> PAGE_SHIFT);
+	#else
+		return drm_prime_pages_to_sg(bo->pages, bo->base.size >> PAGE_SHIFT);
+	#endif
 }
 


### PR DESCRIPTION
Thank you @abucodonosor!

Fixes https://github.com/DisplayLink/evdi/issues/234 courtesy of @abucodonosor.

Confirmed ~~support~~ build for DisplayLink Devel 1.8 on Kernel 5.10.0-rc6-1

~~Not only does it build, but evdi 1.8 is working!~~

Not only does it build, but evdi 1.7 is working!

CC: @bnavigator

```
cat: /etc/redhat-release: No such file or directory
CFLAGS="-Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes -Wno-error=missing-field-initializers" make -C module 
make[1]: Entering directory './evdi/module'
make -C /lib/modules/5.10.0-rc6-1-git/build M=$PWD
make[2]: Entering directory '/usr/lib/modules/5.10.0-rc6-1-git/build'
  CC [M]  ./evdi/module/evdi_drv.o
  CC [M]  ./evdi/module/evdi_modeset.o
  CC [M]  ./evdi/module/evdi_connector.o
  CC [M]  ./evdi/module/evdi_encoder.o
  CC [M]  ./evdi/module/evdi_main.o
  CC [M]  ./evdi/module/evdi_fb.o
  CC [M]  ./evdi/module/evdi_gem.o
  CC [M]  ./evdi/module/evdi_painter.o
  CC [M]  ./evdi/module/evdi_cursor.o
  CC [M]  ./evdi/module/evdi_i2c.o
  CC [M]  ./evdi/module/evdi_ioc32.o
  LD [M]  ./evdi/module/evdi.o
  MODPOST ./evdi/module/Module.symvers
  LD [M]  ./evdi/module/evdi.ko
make[2]: Leaving directory '/usr/lib/modules/5.10.0-rc6-1-git/build'
make[1]: Leaving directory './evdi/module'
CFLAGS="-I../module -Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes -Wno-error=missing-field-initializers " make -C library 
make[1]: Entering directory './evdi/library'
cc -I../module -std=gnu99 -fPIC -I../module -Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes -Wno-error=missing-field-initializers    -c -o evdi_lib.o evdi_lib.c
cc evdi_lib.o -shared -Wl,-soname,libevdi.so.0 -o libevdi.so.1.8.0 -lc -lgcc 
cp libevdi.so.1.8.0 libevdi.so
make[1]: Leaving directory './evdi/library'
```