### PR TITLE
Adjust build for version 1.7.2 release

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -10,7 +10,7 @@ RM ?= rm
 DEPS = evdi_ioctl.h
 CFLAGS := -I../module -std=gnu99 -fPIC $(CFLAGS)
 
-LIBVER := 1.7.0
+LIBVER := 1.7.2
 LIBABI := 0
 
 PREFIX ?= /usr/local

--- a/library/evdi_lib.h
+++ b/library/evdi_lib.h
@@ -13,7 +13,7 @@ extern "C" {
 
 #define LIBEVDI_VERSION_MAJOR 1
 #define LIBEVDI_VERSION_MINOR 7
-#define LIBEVDI_VERSION_PATCH 0
+#define LIBEVDI_VERSION_PATCH 2
 
 struct evdi_lib_version {
 	int version_major;

--- a/module/Makefile
+++ b/module/Makefile
@@ -47,7 +47,7 @@ CP ?= cp
 DKMS ?= dkms
 RM ?= rm
 
-MODVER=1.7.0
+MODVER=1.7.2
 
 ifeq ($(KVER),)
 	KVER := $(shell uname -r)

--- a/module/dkms.conf
+++ b/module/dkms.conf
@@ -7,7 +7,7 @@
 #
 
 PACKAGE_NAME="evdi"
-PACKAGE_VERSION=1.7.0
+PACKAGE_VERSION=1.7.2
 AUTOINSTALL=yes
 
 MAKE[0]="make all INCLUDEDIR=/lib/modules/$kernelver/build/include KVERSION=$kernelver DKMS_BUILD=1"

--- a/module/evdi_drv.h
+++ b/module/evdi_drv.h
@@ -39,11 +39,11 @@
 
 #define DRIVER_NAME   "evdi"
 #define DRIVER_DESC   "Extensible Virtual Display Interface"
-#define DRIVER_DATE   "20200327"
+#define DRIVER_DATE   "20201207"
 
 #define DRIVER_MAJOR 1
 #define DRIVER_MINOR 7
-#define DRIVER_PATCH 0
+#define DRIVER_PATCH 2
 
 struct evdi_fbdev;
 struct evdi_painter;


### PR DESCRIPTION
This patch adjusts the build for the new release version of
evdi to version 1.7.2.