### PR TITLE
Adjustments needed to support the latest kernel for RHEL/CentOS 8 and…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,6 @@
 
 FLAGS=-Werror -Wextra -Wall -Wmissing-prototypes -Wstrict-prototypes -Wno-error=missing-field-initializers
 
-EL8 := $(shell cat /etc/redhat-release | grep -c " 8." )
-ifneq (,$(findstring 1, $(EL8)))
-FLAGS:=$(FLAGS) -D EL8
-endif
-
 all:
 	CFLAGS="$(FLAGS)" $(MAKE) -C module $(MFLAGS)
 	CFLAGS="-I../module $(FLAGS) $(CFLAGS)" $(MAKE) -C library $(MFLAGS)

--- a/module/Makefile
+++ b/module/Makefile
@@ -5,13 +5,19 @@
 # License v2. See the file COPYING in the main directory of this archive for
 # more details.
 #
+
+EL8 := $(shell cat /etc/redhat-release | grep -c " 8." )
+ifneq (,$(findstring 1, $(EL8)))
+EL8FLAG := -DEL8
+endif
+
 ifneq ($(DKMS_BUILD),)
 
 # DKMS
 
 KERN_DIR := /lib/modules/$(KERNELRELEASE)/build
 
-ccflags-y := -Iinclude/drm
+ccflags-y := -Iinclude/drm $(EL8FLAG)
 evdi-y := evdi_drv.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_main.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 obj-m := evdi.o
@@ -35,7 +41,7 @@ ifneq ($(KERNELRELEASE),)
 # Note: this can be removed once it is in kernel tree and Kconfig is properly used
 CONFIG_DRM_EVDI := m
 LINUXINCLUDE := $(subst -I,-isystem,$(LINUXINCLUDE))
-ccflags-y := -isystem include/drm $(CFLAGS)
+ccflags-y := -isystem include/drm $(CFLAGS) $(EL8FLAG)
 evdi-y := evdi_drv.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_main.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 obj-$(CONFIG_DRM_EVDI) := evdi.o

--- a/module/evdi_connector.c
+++ b/module/evdi_connector.c
@@ -105,7 +105,7 @@ static void evdi_connector_destroy(struct drm_connector *connector)
 
 static struct drm_encoder *evdi_best_encoder(struct drm_connector *connector)
 {
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	struct drm_encoder *encoder;
 
 	drm_connector_for_each_possible_encoder(connector, encoder) {

--- a/module/evdi_cursor.c
+++ b/module/evdi_cursor.c
@@ -23,7 +23,7 @@
 #include <linux/mutex.h>
 #include <linux/version.h>
 
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_cursor.h
+++ b/module/evdi_cursor.h
@@ -23,7 +23,7 @@
 
 #include <linux/version.h>
 #include <linux/module.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_drv.c
+++ b/module/evdi_drv.c
@@ -9,7 +9,7 @@
  */
 
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif
@@ -80,7 +80,7 @@ static void evdi_disable_vblank(__always_unused struct drm_device *dev,
 }
 
 static struct drm_driver driver = {
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	.driver_features = DRIVER_MODESET | DRIVER_GEM | DRIVER_ATOMIC,
 #else
 	.driver_features = DRIVER_MODESET | DRIVER_GEM | DRIVER_PRIME

--- a/module/evdi_drv.h
+++ b/module/evdi_drv.h
@@ -17,7 +17,7 @@
 #include <linux/module.h>
 #include <linux/version.h>
 #include <linux/device.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <drm/drm_drv.h>
 #include <drm/drm_fourcc.h>
 #include <drm/drm_ioctl.h>
@@ -30,7 +30,7 @@
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_rect.h>
 #include <drm/drm_gem.h>
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <linux/dma-resv.h>
 #else
 #include <linux/reservation.h>
@@ -68,7 +68,7 @@ struct evdi_gem_object {
 	struct page **pages;
 	void *vmapping;
 	struct sg_table *sg;
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	struct dma_resv *resv;
 	struct dma_resv _resv;
 #else

--- a/module/evdi_encoder.c
+++ b/module/evdi_encoder.c
@@ -12,7 +12,7 @@
  */
 
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -17,7 +17,7 @@
 #endif /* CONFIG_FB */
 #include <linux/dma-buf.h>
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -9,7 +9,7 @@
  */
 
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif
@@ -51,7 +51,7 @@ struct evdi_gem_object *evdi_gem_alloc_object(struct drm_device *dev,
 		return NULL;
 	}
 
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	dma_resv_init(&obj->_resv);
 #else
 	reservation_object_init(&obj->_resv);
@@ -233,7 +233,7 @@ void evdi_gem_free_object(struct drm_gem_object *gem_obj)
 
 	if (gem_obj->dev->vma_offset_manager)
 		drm_gem_free_mmap_offset(gem_obj);
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	dma_resv_fini(&obj->_resv);
 #else
 	reservation_object_fini(&obj->_resv);

--- a/module/evdi_ioc32.c
+++ b/module/evdi_ioc32.c
@@ -22,7 +22,7 @@
 #include <linux/compat.h>
 
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_main.c
+++ b/module/evdi_main.c
@@ -13,7 +13,7 @@
 
 #include <linux/version.h>
 #include <linux/platform_device.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -12,7 +12,7 @@
  */
 
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -10,7 +10,7 @@
 #include "linux/thread_info.h"
 #include "linux/mm.h"
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 #include <drm/drmP.h>
 #endif


### PR DESCRIPTION
… DKMS

- Add preprocessor conditionals - DRM in 8.3 been rebased to upstream
Linux kernel version 5.6

- Fixed DKMS support on RHEL/CentOS 8