### PR TITLE
5.11 fixes by @rockorequin @sickcodes @microhobby for 1.7.x

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -17,7 +17,7 @@ ifneq ($(DKMS_BUILD),)
 
 KERN_DIR := /lib/modules/$(KERNELRELEASE)/build
 
-ccflags-y := -Iinclude/drm $(EL8FLAG)
+ccflags-y := -Iinclude/drm $(EL8FLAG) -DCONFIG_DRM_LEGACY
 evdi-y := evdi_drv.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_main.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 obj-m := evdi.o
@@ -41,7 +41,7 @@ ifneq ($(KERNELRELEASE),)
 # Note: this can be removed once it is in kernel tree and Kconfig is properly used
 CONFIG_DRM_EVDI := m
 LINUXINCLUDE := $(subst -I,-isystem,$(LINUXINCLUDE))
-ccflags-y := -isystem include/drm $(CFLAGS) $(EL8FLAG)
+ccflags-y := -isystem include/drm $(CFLAGS) $(EL8FLAG) -DCONFIG_DRM_LEGACY
 evdi-y := evdi_drv.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_main.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 obj-$(CONFIG_DRM_EVDI) := evdi.o

--- a/module/evdi_drv.c
+++ b/module/evdi_drv.c
@@ -48,7 +48,7 @@ struct drm_ioctl_desc evdi_painter_ioctls[] = {
 			  DRM_UNLOCKED),
 };
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) > LINUX_VERSION_CODE
 static const struct vm_operations_struct evdi_gem_vm_ops = {
 	.fault = evdi_gem_fault,
 	.open = drm_gem_vm_open,
@@ -89,22 +89,22 @@ static struct drm_driver driver = {
 			 | DRIVER_ATOMIC,
 #endif
 	.unload = evdi_driver_unload,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) > LINUX_VERSION_CODE
 	.preclose = evdi_driver_preclose,
 #endif
 
 	.postclose = evdi_driver_postclose,
 
 	/* gem hooks */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
+#if KERNEL_VERSION(5, 9, 0) > LINUX_VERSION_CODE
 	// In 5.9 and below we have gem_free_object
 	.gem_free_object = evdi_gem_free_object,
-#elif LINUX_VERSION_CODE <= KERNEL_VERSION(5, 11, 0)
+#elif KERNEL_VERSION(5, 11, 0) >= LINUX_VERSION_CODE
 	// In 5.9 and 5.10 this is called gem_free_object_unlocked
 	.gem_free_object_unlocked = evdi_gem_free_object,
 	// Note that gem_free_object_unlocked no longer exists in 5.11 - it needs to be added to the gem object instead
 #endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) > LINUX_VERSION_CODE
     // In 5.11+, this is set in the object instance
 	.gem_vm_ops = &evdi_gem_vm_ops,
 #endif
@@ -122,7 +122,7 @@ static struct drm_driver driver = {
 	.prime_fd_to_handle = drm_gem_prime_fd_to_handle,
 	.gem_prime_import = drm_gem_prime_import,
 	.prime_handle_to_fd = drm_gem_prime_handle_to_fd,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) > LINUX_VERSION_CODE
 	// In kernel 5.11, these have been moved to the object instance
 	.gem_prime_export = drm_gem_prime_export,
 	.gem_prime_get_sg_table = evdi_prime_get_sg_table,

--- a/module/evdi_drv.c
+++ b/module/evdi_drv.c
@@ -99,7 +99,7 @@ static struct drm_driver driver = {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
 	// In 5.9 and below we have gem_free_object
 	.gem_free_object = evdi_gem_free_object,
-#elsif LINUX_VERSION_CODE <= KERNEL_VERSION(5, 11, 0)
+#elif LINUX_VERSION_CODE <= KERNEL_VERSION(5, 11, 0)
 	// In 5.9 and 5.10 this is called gem_free_object_unlocked
 	.gem_free_object_unlocked = evdi_gem_free_object,
 	// Note that gem_free_object_unlocked no longer exists in 5.11 - it needs to be added to the gem object instead

--- a/module/evdi_drv.c
+++ b/module/evdi_drv.c
@@ -99,7 +99,7 @@ static struct drm_driver driver = {
 #if KERNEL_VERSION(5, 9, 0) > LINUX_VERSION_CODE
 	// In 5.9 and below we have gem_free_object
 	.gem_free_object = evdi_gem_free_object,
-#elif KERNEL_VERSION(5, 11, 0) >= LINUX_VERSION_CODE
+#elif KERNEL_VERSION(5, 10, 0) >= LINUX_VERSION_CODE
 	// In 5.9 and 5.10 this is called gem_free_object_unlocked
 	.gem_free_object_unlocked = evdi_gem_free_object,
 	// Note that gem_free_object_unlocked no longer exists in 5.11 - it needs to be added to the gem object instead

--- a/module/evdi_drv.c
+++ b/module/evdi_drv.c
@@ -48,11 +48,13 @@ struct drm_ioctl_desc evdi_painter_ioctls[] = {
 			  DRM_UNLOCKED),
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
 static const struct vm_operations_struct evdi_gem_vm_ops = {
 	.fault = evdi_gem_fault,
 	.open = drm_gem_vm_open,
 	.close = drm_gem_vm_close,
 };
+#endif
 
 static const struct file_operations evdi_driver_fops = {
 	.owner = THIS_MODULE,
@@ -87,17 +89,26 @@ static struct drm_driver driver = {
 			 | DRIVER_ATOMIC,
 #endif
 	.unload = evdi_driver_unload,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
 	.preclose = evdi_driver_preclose,
+#endif
 
 	.postclose = evdi_driver_postclose,
 
 	/* gem hooks */
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
-	.gem_free_object_unlocked = evdi_gem_free_object,
-#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
+	// In 5.9 and below we have gem_free_object
 	.gem_free_object = evdi_gem_free_object,
+#elsif LINUX_VERSION_CODE <= KERNEL_VERSION(5, 11, 0)
+	// In 5.9 and 5.10 this is called gem_free_object_unlocked
+	.gem_free_object_unlocked = evdi_gem_free_object,
+	// Note that gem_free_object_unlocked no longer exists in 5.11 - it needs to be added to the gem object instead
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+    // In 5.11+, this is set in the object instance
 	.gem_vm_ops = &evdi_gem_vm_ops,
+#endif
+
 
 	.dumb_create = evdi_dumb_create,
 	.dumb_map_offset = evdi_gem_mmap,
@@ -111,8 +122,11 @@ static struct drm_driver driver = {
 	.prime_fd_to_handle = drm_gem_prime_fd_to_handle,
 	.gem_prime_import = drm_gem_prime_import,
 	.prime_handle_to_fd = drm_gem_prime_handle_to_fd,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+	// In kernel 5.11, these have been moved to the object instance
 	.gem_prime_export = drm_gem_prime_export,
 	.gem_prime_get_sg_table = evdi_prime_get_sg_table,
+#endif
 	.gem_prime_import_sg_table = evdi_prime_import_sg_table,
 
 	.enable_vblank = evdi_enable_vblank,

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -20,7 +20,7 @@
 
 void evdi_gem_free_object(struct drm_gem_object *gem_obj);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 static const struct vm_operations_struct evdi_gem_vm_ops = {
 	.fault = evdi_gem_fault,
 	.open = drm_gem_vm_open,
@@ -52,7 +52,7 @@ struct evdi_gem_object *evdi_gem_alloc_object(struct drm_device *dev,
 					      size_t size)
 {
 	struct evdi_gem_object *obj;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 	struct drm_gem_object_funcs *funcs;
 #endif
 
@@ -65,7 +65,7 @@ struct evdi_gem_object *evdi_gem_alloc_object(struct drm_device *dev,
 		return NULL;
 	}
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 	funcs = kzalloc(sizeof(struct drm_gem_object_funcs), GFP_KERNEL);
 	if (funcs == NULL) {
 		kfree(obj);
@@ -218,7 +218,7 @@ int evdi_gem_vmap(struct evdi_gem_object *obj)
 	int ret;
 
 	if (obj->base.import_attach) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) > LINUX_VERSION_CODE
 		obj->vmapping = dma_buf_vmap(obj->base.import_attach->dmabuf);
 #else
 		dma_buf_vmap(obj->base.import_attach->dmabuf, &map);
@@ -277,7 +277,7 @@ void evdi_gem_free_object(struct drm_gem_object *gem_obj)
 #endif
 	obj->resv = NULL;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 	// We allocated this in evdi_gem_alloc_object
 	kfree(obj->base.funcs);
 #endif

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -56,7 +56,11 @@ static void evdi_crtc_set_nofb(__always_unused struct drm_crtc *crtc)
 
 static void evdi_crtc_atomic_flush(
 	struct drm_crtc *crtc
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
 	, __always_unused struct drm_crtc_state *old_state
+#else
+	, __always_unused struct drm_atomic_state *old_state
+#endif
 	)
 {
 	struct drm_crtc_state *state = crtc->state;

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -56,7 +56,7 @@ static void evdi_crtc_set_nofb(__always_unused struct drm_crtc *crtc)
 
 static void evdi_crtc_atomic_flush(
 	struct drm_crtc *crtc
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+#if KERNEL_VERSION(5, 11, 0) > LINUX_VERSION_CODE
 	, __always_unused struct drm_crtc_state *old_state
 #else
 	, __always_unused struct drm_atomic_state *old_state


### PR DESCRIPTION

DO NOT MERGE

New warning: no longer works for 5.11. Do not use.

Warning: pulling your screen out on 5.11 will lock up your PC. Be careful regarding data loss, using LTS kernel is actually safer for now...

Fixes https://github.com/DisplayLink/evdi/issues/249

Applies patch by @rockorequin:

https://gist.githubusercontent.com/rockorequin/f3047e748bcba9be9d1fff06f472dbda/raw/93b4792bb11ffe0a77973a6335d3e5c751dcf053/evdi-devel-5.11-rc2.patch

And additional fixes by @microhobby

Confirmed build and external display working by @sickcodes 5.11-rc6 https://github.com/DisplayLink/evdi/issues/249#issuecomment-772047463

Confirmed build on 5.8 & 5.11-rc7 by @rockorequin https://github.com/DisplayLink/evdi/issues/249#issuecomment-775651416

