### PR TITLE
add an option to disable fast path texture import, work-around for slow AMD copy (gnome/wayland)

### DIFF
--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -14,6 +14,7 @@
 #include <drm/drmP.h>
 #endif
 #include "evdi_drm_drv.h"
+#include "evdi_params.h"
 #include <linux/shmem_fs.h>
 #include <linux/dma-buf.h>
 #include <drm/drm_cache.h>
@@ -343,6 +344,9 @@ evdi_prime_import_sg_table(struct drm_device *dev,
 {
 	struct evdi_gem_object *obj;
 	int npages;
+
+  if (evdi_disable_texture_import)
+    return ERR_PTR(-ENOMEM);
 
 	obj = evdi_gem_alloc_object(dev, attach->dmabuf->size);
 	if (IS_ERR(obj))

--- a/module/evdi_params.c
+++ b/module/evdi_params.c
@@ -15,6 +15,7 @@
 
 unsigned int evdi_loglevel __read_mostly = EVDI_LOGLEVEL_DEBUG;
 unsigned short int evdi_initial_device_count __read_mostly;
+unsigned short int evdi_disable_texture_import = 0;
 
 module_param_named(initial_loglevel, evdi_loglevel, int, 0400);
 MODULE_PARM_DESC(initial_loglevel, "Initial log level");
@@ -22,3 +23,7 @@ MODULE_PARM_DESC(initial_loglevel, "Initial log level");
 module_param_named(initial_device_count,
 		   evdi_initial_device_count, ushort, 0644);
 MODULE_PARM_DESC(initial_device_count, "Initial DRM device count (default: 0)");
+
+module_param_named(disable_texture_import,
+		   evdi_disable_texture_import, ushort, 0644);
+MODULE_PARM_DESC(disable_texture_import, "Disable fast path GPU texture import (default: 0, set 1 to disable)");

--- a/module/evdi_params.h
+++ b/module/evdi_params.h
@@ -11,5 +11,6 @@
 
 extern unsigned int evdi_loglevel;
 extern unsigned short int evdi_initial_device_count;
+extern unsigned short int evdi_disable_texture_import;
 
 #endif /* EVDI_PARAMS_H */


### PR DESCRIPTION
DisplayLink screen is unusable when connected to an AMD system due to a very slow refresh rate. 
 
**Configuration:**
- Dock: 17e9:6008 DisplayLink Targus USB3 DV4K DOCK w PD100W
- APU: AMD Ryzen 7 PRO 4750U with Radeon Graphics
- 4K screen connected to the Targus dock.
- Debian/Bullseye/Kernel 5.10.0-6-amd64, standard amdgpu opensource driver with Gnome 3.38.4

**Analysis**
Slow screen refresh rate seems to be related to a very slow texture copy in the EVDI module. This can be measured using bpftrace. The output shows that all copies take around 120ms (4K screen), which explains observable slow refresh rate.

`bpftrace -e 'kprobe:evdi_painter_grabpix_ioctl { @beg = nsecs; } kretprobe:evdi_painter_grabpix_ioctl { $end = nsecs; @["frame_copy_ms"] = lhist(($end - @beg)/1000000, 1, 200, 1);}'
Attaching 2 probes...
^C

@[frame_copy_ms]:
[119, 120)             2 |@@@@                                                |
[120, 121)            21 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[121, 122)             9 |@@@@@@@@@@@@@@@@@@@@@@                              |
[122, 123)            14 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  |
`
I am not sure what is the root-cause of that slow copy on AMD systems (Intel does not suffer from it). Possibly the texture is bound to the GPU domain not easily accessible by the CPU. This would be worth investigating further. This problem renders mutter's "zero-copy" optimisation [https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/810](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/810) unusable on AMD systems at the moment. Mutter's strategy is to try the fast path first and if that does not work it will fall back on "primary GPU copy". The issue is that import technically succeeds, but then it is unusable. 

**Solution**
Fail GPU texture import in EVDI and make mutter switch to its fallback scenario. Fixing this in EVDI is probably easier than in mutter. The solution means one more copy, but we have two fast copies instead of one that was dreadfully slow. This leads to much improved copy times in EVDI. 
After building the modified evdi and adding  `options evdi disable_texture_import=1` to `/etc/modprobe/evdi.conf` the following framebuffer copy times were measured (~5ms per frame):

`bpftrace -e 'kprobe:evdi_painter_grabpix_ioctl { @beg = nsecs; } kretprobe:evdi_painter_grabpix_ioctl { $end = nsecs; @["frame_copy_ms"] = lhist(($end - @beg)/1000000, 1, 200, 1);}'

@[frame_copy_ms]: 
[4, 5)                 1 |                                                    |
[5, 6)               140 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[6, 7)                64 |@@@@@@@@@@@@@@@@@@@@@@@                             |
[7, 8)                 1 |                                                    |
[8, 9)                 4 |@                                                   |
[9, 10)                1 | `

This is just work-around, but it makes Displaylink screen(s) perform quite well on AMD systems.