### PR TITLE
Linux 5.13 support

### DIFF
--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -25,7 +25,11 @@
 #include "evdi_drm_drv.h"
 #include "evdi_cursor.h"
 #include "evdi_params.h"
+#if KERNEL_VERSION(5, 13, 0) < LINUX_VERSION_CODE
 #include <drm/drm_gem_framebuffer_helper.h>
+#else
+#include <drm/drm_gem_atomic_helper.h>
+#endif
 
 static void evdi_crtc_dpms(__always_unused struct drm_crtc *crtc,
 			   __always_unused int mode)
@@ -345,12 +349,20 @@ static void evdi_cursor_atomic_update(struct drm_plane *plane,
 
 static const struct drm_plane_helper_funcs evdi_plane_helper_funcs = {
 	.atomic_update = evdi_plane_atomic_update,
+#if KERNEL_VERSION(5, 13, 0) < LINUX_VERSION_CODE
 	.prepare_fb = drm_gem_fb_prepare_fb
+#else
+	.prepare_fb = drm_gem_plane_helper_prepare_fb
+#endif
 };
 
 static const struct drm_plane_helper_funcs evdi_cursor_helper_funcs = {
 	.atomic_update = evdi_cursor_atomic_update,
+#if KERNEL_VERSION(5, 13, 0) < LINUX_VERSION_CODE
 	.prepare_fb = drm_gem_fb_prepare_fb
+#else
+	.prepare_fb = drm_gem_plane_helper_prepare_fb
+#endif
 };
 
 static const struct drm_plane_funcs evdi_plane_funcs = {

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -203,8 +203,16 @@ static const struct drm_crtc_funcs evdi_crtc_funcs = {
 };
 
 static void evdi_plane_atomic_update(struct drm_plane *plane,
-				     struct drm_plane_state *old_state)
+#if KERNEL_VERSION(5, 13, 0) < LINUX_VERSION_CODE
+				     struct drm_plane_state *old_state
+#else
+				     struct drm_atomic_state *atom_state
+#endif
+		)
 {
+#if KERNEL_VERSION(5, 13, 0) >= LINUX_VERSION_CODE
+	struct drm_plane_state *old_state = drm_atomic_get_old_plane_state(atom_state, plane);
+#endif
 	struct drm_plane_state *state;
 	struct evdi_device *evdi;
 	struct evdi_painter *painter;
@@ -268,8 +276,16 @@ static void evdi_cursor_atomic_get_rect(struct drm_clip_rect *rect,
 }
 
 static void evdi_cursor_atomic_update(struct drm_plane *plane,
-				      struct drm_plane_state *old_state)
+#if KERNEL_VERSION(5, 13, 0) < LINUX_VERSION_CODE
+				     struct drm_plane_state *old_state
+#else
+				     struct drm_atomic_state *atom_state
+#endif
+		)
 {
+#if KERNEL_VERSION(5, 13, 0) >= LINUX_VERSION_CODE
+	struct drm_plane_state *old_state = drm_atomic_get_old_plane_state(atom_state, plane);
+#endif
 	if (plane && plane->state && plane->dev && plane->dev->dev_private) {
 		struct drm_plane_state *state = plane->state;
 		struct evdi_device *evdi = plane->dev->dev_private;


### PR DESCRIPTION
    See also upstream:
    
    commit 820c1707177c6fe96beed7f8cc842a683afbf890
    Author: Thomas Zimmermann <tzimmermann@suse.de>
    Date:   Mon Feb 22 15:17:56 2021 +0100
    
        drm/gem: Move drm_gem_fb_prepare_fb() to GEM atomic helpers

and

    commit 977697e20b3d758786b67edc33941e5c410ffe4d
    Author: Maxime Ripard <maxime@cerno.tech>
    Date:   Fri Feb 19 13:00:29 2021 +0100
    
        drm/atomic: Pass the full state to planes atomic disable and update
