### PR TITLE
Fix Compile On RHEL 8.4 and Derivatives

### DIFF
--- a/module/evdi_cursor.c
+++ b/module/evdi_cursor.c
@@ -55,7 +55,7 @@ static void evdi_cursor_set_gem(struct evdi_cursor *cursor,
 	if (obj)
 		drm_gem_object_get(&obj->base);
 	if (cursor->obj)
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 		drm_gem_object_put(&cursor->obj->base);
 #else
 		drm_gem_object_put_unlocked(&cursor->obj->base);

--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -79,7 +79,7 @@ static void evdi_disable_vblank(__always_unused struct drm_device *dev,
 #endif
 
 static struct drm_driver driver = {
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	.driver_features = DRIVER_MODESET | DRIVER_GEM | DRIVER_ATOMIC,
 #else
 	.driver_features = DRIVER_MODESET | DRIVER_GEM | DRIVER_PRIME
@@ -91,7 +91,7 @@ static struct drm_driver driver = {
 
 	/* gem hooks */
 #if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
-#elif KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#elif KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	.gem_free_object_unlocked = evdi_gem_free_object,
 #else
 	.gem_free_object = evdi_gem_free_object,

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -319,7 +319,7 @@ static void evdi_user_framebuffer_destroy(struct drm_framebuffer *fb)
 
 	EVDI_CHECKPT();
 	if (efb->obj)
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 		drm_gem_object_put(&efb->obj->base);
 #else
 		drm_gem_object_put_unlocked(&efb->obj->base);
@@ -441,7 +441,7 @@ static int evdifb_create(struct drm_fb_helper *helper,
 
 	return ret;
  out_gfree:
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	drm_gem_object_put(&efbdev->efb.obj->base);
 #else
 	drm_gem_object_put_unlocked(&efbdev->efb.obj->base);
@@ -471,7 +471,7 @@ static void evdi_fbdev_destroy(__always_unused struct drm_device *dev,
 	if (efbdev->efb.obj) {
 		drm_framebuffer_unregister_private(&efbdev->efb.base);
 		drm_framebuffer_cleanup(&efbdev->efb.base);
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 		drm_gem_object_put(&efbdev->efb.obj->base);
 #else
 		drm_gem_object_put_unlocked(&efbdev->efb.obj->base);
@@ -493,7 +493,7 @@ int evdi_fbdev_init(struct drm_device *dev)
 	evdi->fbdev = efbdev;
 	drm_fb_helper_prepare(dev, &efbdev->helper, &evdi_fb_helper_funcs);
 
-#if KERNEL_VERSION(5, 7, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 7, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	ret = drm_fb_helper_init(dev, &efbdev->helper);
 #else
 	ret = drm_fb_helper_init(dev, &efbdev->helper, 1);
@@ -503,7 +503,7 @@ int evdi_fbdev_init(struct drm_device *dev)
 		return ret;
 	}
 
-#if KERNEL_VERSION(5, 7, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 7, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 	drm_fb_helper_single_add_all_connectors(&efbdev->helper);
 #endif

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -345,8 +345,8 @@ evdi_prime_import_sg_table(struct drm_device *dev,
 	struct evdi_gem_object *obj;
 	int npages;
 
-  if (evdi_disable_texture_import)
-    return ERR_PTR(-ENOMEM);
+	if (evdi_disable_texture_import)
+		return ERR_PTR(-ENOMEM);
 
 	obj = evdi_gem_alloc_object(dev, attach->dmabuf->size);
 	if (IS_ERR(obj))

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -102,7 +102,7 @@ evdi_gem_create(struct drm_file *file,
 		kfree(obj);
 		return ret;
 	}
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	drm_gem_object_put(&obj->base);
 #else
 	drm_gem_object_put_unlocked(&obj->base);
@@ -372,7 +372,7 @@ evdi_prime_import_sg_table(struct drm_device *dev,
 struct sg_table *evdi_prime_get_sg_table(struct drm_gem_object *obj)
 {
 	struct evdi_gem_object *bo = to_evdi_bo(obj);
-	#if KERNEL_VERSION(5, 10, 0) <= LINUX_VERSION_CODE
+	#if KERNEL_VERSION(5, 10, 0) <= LINUX_VERSION_CODE || defined(EL8)
 		return drm_prime_pages_to_sg(obj->dev, bo->pages, bo->base.size >> PAGE_SHIFT);
 	#else
 		return drm_prime_pages_to_sg(bo->pages, bo->base.size >> PAGE_SHIFT);

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -133,7 +133,7 @@ static int evdi_crtc_cursor_set(struct drm_crtc *crtc,
 	evdi_cursor_set(evdi->cursor,
 			eobj, width, height, hot_x, hot_y,
 			format, stride);
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	drm_gem_object_put(obj);
 #else
 	drm_gem_object_put_unlocked(obj);

--- a/module/evdi_params.c
+++ b/module/evdi_params.c
@@ -15,7 +15,7 @@
 
 unsigned int evdi_loglevel __read_mostly = EVDI_LOGLEVEL_DEBUG;
 unsigned short int evdi_initial_device_count __read_mostly;
-unsigned short int evdi_disable_texture_import;
+unsigned short int evdi_disable_texture_import __read_mostly;
 
 module_param_named(initial_loglevel, evdi_loglevel, int, 0400);
 MODULE_PARM_DESC(initial_loglevel, "Initial log level");

--- a/module/evdi_params.c
+++ b/module/evdi_params.c
@@ -15,7 +15,7 @@
 
 unsigned int evdi_loglevel __read_mostly = EVDI_LOGLEVEL_DEBUG;
 unsigned short int evdi_initial_device_count __read_mostly;
-unsigned short int evdi_disable_texture_import = 0;
+unsigned short int evdi_disable_texture_import;
 
 module_param_named(initial_loglevel, evdi_loglevel, int, 0400);
 MODULE_PARM_DESC(initial_loglevel, "Initial log level");

--- a/module/evdi_platform_dev.c
+++ b/module/evdi_platform_dev.c
@@ -21,7 +21,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/platform_device.h>
 #include <linux/slab.h>
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <linux/iommu.h>
 #endif
 
@@ -61,7 +61,7 @@ int evdi_platform_device_probe(struct platform_device *pdev)
 	struct drm_device *dev;
 	struct evdi_platform_device_data *data;
 
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #if IS_ENABLED(CONFIG_IOMMU_API) && defined(CONFIG_INTEL_IOMMU)
 	struct dev_iommu iommu;
 #endif
@@ -73,7 +73,7 @@ int evdi_platform_device_probe(struct platform_device *pdev)
 		return -ENOMEM;
 /* Intel-IOMMU workaround: platform-bus unsupported, force ID-mapping */
 #if IS_ENABLED(CONFIG_IOMMU_API) && defined(CONFIG_INTEL_IOMMU)
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined (EL8)
 	memset(&iommu, 0, sizeof(iommu));
 	iommu.priv = (void *)-1;
 	pdev->dev.iommu = &iommu;

--- a/module/evdi_platform_dev.c
+++ b/module/evdi_platform_dev.c
@@ -73,7 +73,7 @@ int evdi_platform_device_probe(struct platform_device *pdev)
 		return -ENOMEM;
 /* Intel-IOMMU workaround: platform-bus unsupported, force ID-mapping */
 #if IS_ENABLED(CONFIG_IOMMU_API) && defined(CONFIG_INTEL_IOMMU)
-#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined (EL8)
+#if KERNEL_VERSION(5, 9, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	memset(&iommu, 0, sizeof(iommu));
 	iommu.priv = (void *)-1;
 	pdev->dev.iommu = &iommu;


### PR DESCRIPTION
This patch allows evdi to be compiled on RHEL 8.4 and its derivatives.

After running the `ci/run_style_check`, there were some fixes that needed to be made. That is included in this change.

Fixes #283 