### PR TITLE
Fix compilation when building with clang

### DIFF
--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -85,6 +85,7 @@ struct drm_clip_rect evdi_framebuffer_sanitize_rect(
 	return rect;
 }
 
+#ifdef CONFIG_FB
 static int evdi_handle_damage(struct evdi_framebuffer *fb,
 		       int x, int y, int width, int height)
 {
@@ -104,7 +105,6 @@ static int evdi_handle_damage(struct evdi_framebuffer *fb,
 	return 0;
 }
 
-#ifdef CONFIG_FB
 static int evdi_fb_mmap(struct fb_info *info, struct vm_area_struct *vma)
 {
 	unsigned long start = vma->vm_start;


### PR DESCRIPTION
Clang is stricter when reporting errors. In this case, when building
with CONFIG_FB unset, compiling with clang will produce the following
error:
evdi_fb.c:88:12: error: unused function 'evdi_handle_damage' [-Werror,-Wunused-function]
static int evdi_handle_damage(struct evdi_framebuffer *fb,
           ^
1 error generated.

Since evdi_handle_damage() is only used when CONFIG_FB is set, move the
`ifdef CONFIG_FB` to encapsulate the evdi_handle_damage() function.

Tested with copy of evdi imported into the chromeos-5.10 kernel.

Before submitting the PR please make sure you have run *ci* scripts:
  * `./ci/build_against_kernel` (see `--help` for all options)
    We need backward compatibility and this script is a handy way of testing
    build compliance with many kernel versions.
  * `./ci/run_style_check`
    We want to be as style compliant as possible. Again, this is a handy way of
    checking it.

If you have more than one change consider creating separate PRs for them; it
will make the review process much easier. Also provide some description (links
to source code or mailing list are welcome - this might help to understand the
change).

Thanks for the contribution!
