### PR TITLE
hardware cursor - switch to cursor planes

### DIFF
--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -671,8 +671,11 @@ void evdi_painter_send_update_ready_if_needed(struct evdi_painter *painter)
 	EVDI_CHECKPT();
 	if (painter) {
 		painter_lock(painter);
-
+#if KERNEL_VERSION(5, 10, 0) <= LINUX_VERSION_CODE
+		if (painter->was_update_requested && painter->num_dirts) {
+#else
 		if (painter->was_update_requested) {
+#endif
 			evdi_painter_send_update_ready(painter);
 			painter->was_update_requested = false;
 		}


### PR DESCRIPTION
Hi DisplayLink, 

The hardware cursor is broken on Gnome 40++, hence the performance is not good. It looks like Gnome now requires the cursor to be passed via the cursor plane and not legacy API. This MR implements it.

Unfortunately it seems that the driver cannot advertise both APIs and let the compositor choose the one it wants (advertising both causes bug-check in DRM). I can see the need for a compile time switch between the two, but I do not know what rule I should implement (ideas?). 

Anyway, it works on Gnome 41 (Fedora 35), Gnome 40 (Debian/Bookworm) and Gnome 3.38 (Debian/Bullseye, this one actually works with the old and new API). I have not tested any Ubuntu variants. 

CI:
* Style-check - OK (unrelated warning) 
* Kernel builds: 5.X OK, master fails (unrelated).

Thanks.
Piotr

