### PR TITLE
Fix dma-buf crash on kernel 5.11+

### DIFF
--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -59,6 +59,9 @@ struct evdi_gem_object {
 	struct drm_gem_object base;
 	struct page **pages;
 	void *vmapping;
+#if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
+	bool vmap_is_iomem;
+#endif
 	struct sg_table *sg;
 #if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	struct dma_resv *resv;

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -238,6 +238,7 @@ int evdi_gem_vmap(struct evdi_gem_object *obj)
 		if (ret)
 			return -ENOMEM;
 		obj->vmapping = map.vaddr;
+		obj->vmap_is_iomem = map.is_iomem;
 #else
 		obj->vmapping = dma_buf_vmap(obj->base.import_attach->dmabuf);
 		if (!obj->vmapping)
@@ -260,7 +261,9 @@ void evdi_gem_vunmap(struct evdi_gem_object *obj)
 {
 	if (obj->base.import_attach) {
 #if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
-		struct dma_buf_map map = DMA_BUF_MAP_INIT_VADDR(obj->vmapping);
+		struct dma_buf_map map;
+		if (obj->vmap_is_iomem) { dma_buf_map_set_vaddr_iomem(&map, obj->vmapping); }
+		else { dma_buf_map_set_vaddr(&map, obj->vmapping); }
 
 		dma_buf_vunmap(obj->base.import_attach->dmabuf, &map);
 #else

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -262,8 +262,11 @@ void evdi_gem_vunmap(struct evdi_gem_object *obj)
 	if (obj->base.import_attach) {
 #if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 		struct dma_buf_map map;
-		if (obj->vmap_is_iomem) { dma_buf_map_set_vaddr_iomem(&map, obj->vmapping); }
-		else { dma_buf_map_set_vaddr(&map, obj->vmapping); }
+
+		if (obj->vmap_is_iomem)
+			dma_buf_map_set_vaddr_iomem(&map, obj->vmapping);
+		else
+			dma_buf_map_set_vaddr(&map, obj->vmapping);
 
 		dma_buf_vunmap(obj->base.import_attach->dmabuf, &map);
 #else


### PR DESCRIPTION
Tested on 5.14, but it should fix it on 5.11-5.13 as well.

Seems that the `is_iomem` flag is set to `true` under nvidia blob drivers, causing the `BUG_ON(!dma_buf_map_is_equal(&dmabuf->vmap_ptr, map));` check in `dma_buf_vunmap` to trigger since `evdi_gem_vunmap` explicitly set it to `false`.

This should solve #288, #300, and #313.