### PR TITLE
Fix crashes with dmabufs not from external kernel modules

### DIFF
--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -62,10 +62,10 @@ static bool evdi_was_called_by_mutter(void)
 
 static bool evdi_drm_gem_object_use_import_attach(struct drm_gem_object *obj)
 {
-	if (!obj || !obj->import_attach)
+	if (!obj || !obj->import_attach || !obj->import_attach->dmabuf->owner)
 		return false;
 
-	return obj->import_attach && strcmp(obj->import_attach->dmabuf->owner->name, "amdgpu") != 0;
+	return strcmp(obj->import_attach->dmabuf->owner->name, "amdgpu") != 0;
 }
 
 uint32_t evdi_gem_object_handle_lookup(struct drm_file *filp,


### PR DESCRIPTION
In particular, when software rendering, it is entirely possible to have
a dmabuf that did not come from an externally loaded kernel module. As a
result, the owner field is NULL, and checking the owner's name
segfaults.

Tested on the Asahi Linux kernel, where software rendering is used.