### PR TITLE
Fix Compiling On EL 8 Systems

### DIFF
--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -24,7 +24,7 @@
 #if KERNEL_VERSION(5, 1, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <drm/drm_probe_helper.h>
 #endif
-#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <drm/drm_managed.h>
 #endif
 #include <drm/drm_atomic_helper.h>
@@ -146,7 +146,7 @@ static struct drm_driver driver = {
 	.patchlevel = DRIVER_PATCH,
 };
 
-#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
 static void evdi_drm_device_release_cb(__always_unused struct drm_device *dev,
 				       __always_unused void *ptr)
 {
@@ -192,7 +192,7 @@ static int evdi_drm_device_setup(struct drm_device *dev)
 
 	drm_kms_helper_poll_init(dev);
 
-#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	ret = drmm_add_action_or_reset(dev, evdi_drm_device_release_cb, NULL);
 	if (ret)
 		goto err_fb;

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -29,7 +29,7 @@
 #include "evdi_drm_drv.h"
 #include "evdi_cursor.h"
 #include "evdi_params.h"
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <drm/drm_gem_atomic_helper.h>
 #else
 #include <drm/drm_gem_framebuffer_helper.h>
@@ -220,14 +220,14 @@ static const struct drm_crtc_funcs evdi_crtc_funcs = {
 };
 
 static void evdi_plane_atomic_update(struct drm_plane *plane,
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 				     struct drm_atomic_state *atom_state
 #else
 				     struct drm_plane_state *old_state
 #endif
 		)
 {
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	struct drm_plane_state *old_state = drm_atomic_get_old_plane_state(atom_state, plane);
 #else
 #endif
@@ -318,14 +318,14 @@ static void evdi_cursor_atomic_get_rect(struct drm_clip_rect *rect,
 }
 
 static void evdi_cursor_atomic_update(struct drm_plane *plane,
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 				     struct drm_atomic_state *atom_state
 #else
 				     struct drm_plane_state *old_state
 #endif
 		)
 {
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	struct drm_plane_state *old_state = drm_atomic_get_old_plane_state(atom_state, plane);
 #else
 #endif
@@ -395,7 +395,7 @@ static void evdi_cursor_atomic_update(struct drm_plane *plane,
 
 static const struct drm_plane_helper_funcs evdi_plane_helper_funcs = {
 	.atomic_update = evdi_plane_atomic_update,
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	.prepare_fb = drm_gem_plane_helper_prepare_fb
 #else
 	.prepare_fb = drm_gem_fb_prepare_fb
@@ -404,7 +404,7 @@ static const struct drm_plane_helper_funcs evdi_plane_helper_funcs = {
 
 static const struct drm_plane_helper_funcs evdi_cursor_helper_funcs = {
 	.atomic_update = evdi_cursor_atomic_update,
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	.prepare_fb = drm_gem_plane_helper_prepare_fb
 #else
 	.prepare_fb = drm_gem_fb_prepare_fb
@@ -538,7 +538,7 @@ void evdi_modeset_init(struct drm_device *dev)
 
 void evdi_modeset_cleanup(__maybe_unused struct drm_device *dev)
 {
-#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 	drm_mode_config_cleanup(dev);
 #endif

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -727,7 +727,7 @@ void evdi_painter_dpms_notify(struct evdi_device *evdi, int mode)
 static void evdi_log_pixel_format(uint32_t pixel_format,
 		char *buf, size_t size)
 {
-#if KERNEL_VERSION(5, 14, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 14, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	snprintf(buf, size, "pixel format %p4cc", &pixel_format);
 #else
 	struct drm_format_name_buf format_name;


### PR DESCRIPTION
There are backports from newer kernels that have been put in the
older kernels support by EL 8 based systems.  This patch fixes
compiling on such systems.