### PR TITLE
support USB-less systems

### DIFF
--- a/module/evdi_platform_drv.c
+++ b/module/evdi_platform_drv.c
@@ -12,7 +12,9 @@
 #include <linux/module.h>
 #include <linux/platform_device.h>
 #include <linux/dma-mapping.h>
+#ifdef CONFIG_USB_SUPPORT
 #include <linux/usb.h>
+#endif
 
 #include "evdi_params.h"
 #include "evdi_debug.h"
@@ -30,7 +32,9 @@ static struct evdi_platform_drv_context {
 	struct device *root_dev;
 	unsigned int dev_count;
 	struct platform_device *devices[EVDI_DEVICE_COUNT_MAX];
+#ifdef CONFIG_USB_SUPPORT
 	struct notifier_block usb_notifier;
+#endif
 	struct mutex lock;
 } g_ctx;
 
@@ -40,6 +44,7 @@ static struct evdi_platform_drv_context {
 #define evdi_platform_drv_context_unlock(ctx) \
 		mutex_unlock(&ctx->lock)
 
+#ifdef CONFIG_USB_SUPPORT
 static int evdi_platform_drv_usb(__always_unused struct notifier_block *nb,
 		unsigned long action,
 		void *data)
@@ -69,6 +74,7 @@ static int evdi_platform_drv_usb(__always_unused struct notifier_block *nb,
 	}
 	return 0;
 }
+#endif
 
 static int evdi_platform_drv_get_free_idx(struct evdi_platform_drv_context *ctx)
 {
@@ -213,11 +219,15 @@ static int __init evdi_init(void)
 
 	memset(&g_ctx, 0, sizeof(g_ctx));
 	g_ctx.root_dev = root_device_register(DRIVER_NAME);
+#ifdef CONFIG_USB_SUPPORT
 	g_ctx.usb_notifier.notifier_call = evdi_platform_drv_usb;
+#endif
 	mutex_init(&g_ctx.lock);
 	dev_set_drvdata(g_ctx.root_dev, &g_ctx);
 
+#ifdef CONFIG_USB_SUPPORT
 	usb_register_notify(&g_ctx.usb_notifier);
+#endif
 	evdi_sysfs_init(g_ctx.root_dev);
 	ret = platform_driver_register(&evdi_platform_driver);
 	if (ret)
@@ -238,7 +248,9 @@ static void __exit evdi_exit(void)
 
 	if (!PTR_ERR_OR_ZERO(g_ctx.root_dev)) {
 		evdi_sysfs_exit(g_ctx.root_dev);
+#ifdef CONFIG_USB_SUPPORT
 		usb_unregister_notify(&g_ctx.usb_notifier);
+#endif
 		dev_set_drvdata(g_ctx.root_dev, NULL);
 		root_device_unregister(g_ctx.root_dev);
 	}

--- a/module/evdi_sysfs.c
+++ b/module/evdi_sysfs.c
@@ -51,6 +51,7 @@ struct evdi_usb_addr {
 	struct usb_device *usb;
 };
 
+#ifdef CONFIG_USB_SUPPORT
 static int evdi_platform_device_attach(struct device *device,
 		struct evdi_usb_addr *parent_addr);
 
@@ -165,6 +166,16 @@ static int evdi_platform_device_attach(struct device *device,
 	parent = &parent_addr->usb->dev;
 	return evdi_platform_device_add(device, parent);
 }
+
+#else /* !CONFIG_USB_SUPPORT */
+
+static ssize_t add_device_with_usb_path(struct device *dev,
+			 const char *buf, size_t count)
+{
+	return -EINVAL;
+}
+
+#endif /* CONFIG_USB_SUPPORT */
 
 static ssize_t add_store(struct device *dev,
 			 __always_unused struct device_attribute *attr,


### PR DESCRIPTION
Allow to use evdi in systems with USB support disabled.

Signed-off-by: Andrea Righi <andrea.righi@canonical.com>