### PR TITLE
Add support for kernel 6.0 + a minor fix

### DIFF
--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -27,11 +27,11 @@
 #endif
 #if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
 #include <drm/drm_legacy.h>
-#else
-#include <drm/drm_irq.h>
 #if KERNEL_VERSION(6, 0, 0) <= LINUX_VERSION_CODE
 #include <drm/drm_framebuffer.h>
 #endif
+#else
+#include <drm/drm_irq.h>
 #endif
 #include <drm/drm_crtc.h>
 #include <drm/drm_crtc_helper.h>

--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -28,10 +28,9 @@
 #if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
 #include <drm/drm_legacy.h>
 #else
-#if LINUX_VERSION(6, 0, 0) >= LINUX_VERSION_CODE
-#include <drm/drm_framebuffer.h>
-#else
 #include <drm/drm_irq.h>
+#if KERNEL_VERSION(6, 0, 0) <= LINUX_VERSION_CODE
+#include <drm/drm_framebuffer.h>
 #endif
 #endif
 #include <drm/drm_crtc.h>

--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -30,6 +30,7 @@
 #else
 #include <drm/drm_irq.h>
 #endif
+#include <drm/drm_framebuffer.h>
 #include <drm/drm_crtc.h>
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_rect.h>

--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -26,11 +26,11 @@
 #include <drm/drmP.h>
 #endif
 #if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
+#include <drm/drm_framebuffer.h>
 #include <drm/drm_legacy.h>
 #else
 #include <drm/drm_irq.h>
 #endif
-#include <drm/drm_framebuffer.h>
 #include <drm/drm_crtc.h>
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_rect.h>

--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -26,10 +26,13 @@
 #include <drm/drmP.h>
 #endif
 #if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
-#include <drm/drm_framebuffer.h>
 #include <drm/drm_legacy.h>
 #else
+#if LINUX_VERSION(6, 0, 0) >= LINUX_VERSION_CODE
+#include <drm/drm_framebuffer.h>
+#else
 #include <drm/drm_irq.h>
+#endif
 #endif
 #include <drm/drm_crtc.h>
 #include <drm/drm_crtc_helper.h>

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -885,7 +885,7 @@ evdi_painter_connect(struct evdi_device *evdi,
 
 	painter_lock(painter);
 
-		evdi->pixel_area_limit = pixel_area_limit;
+	evdi->pixel_area_limit = pixel_area_limit;
 	evdi->pixel_per_second_limit = pixel_per_second_limit;
 	painter->drm_filp = file;
 	kfree(painter->edid);

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -885,7 +885,7 @@ evdi_painter_connect(struct evdi_device *evdi,
 
 	painter_lock(painter);
 
-        evdi->pixel_area_limit = pixel_area_limit;
+		evdi->pixel_area_limit = pixel_area_limit;
 	evdi->pixel_per_second_limit = pixel_per_second_limit;
 	painter->drm_filp = file;
 	kfree(painter->edid);


### PR DESCRIPTION
Fixes https://github.com/DisplayLink/evdi/issues/376 by implementing @Crashdummyy's fix as posted [here](https://github.com/DisplayLink/evdi/issues/376#issuecomment-1237450695), +  fixes the style used in evdi_painter.c 

Before submitting the PR please make sure you have run *ci* scripts:
  * `./ci/build_against_kernel` (see `--help` for all options) (done)
    We need backward compatibility and this script is a handy way of testing
    build compliance with many kernel versions.
  * `./ci/run_style_check` (done)
    We want to be as style compliant as possible. Again, this is a handy way of
    checking it.

If you have more than one change consider creating separate PRs for them; it
will make the review process much easier. Also provide some description (links
to source code or mailing list are welcome - this might help to understand the
change).

Thanks for the contribution!
