### PR TITLE
Use simple format string for name since printf args are checked now

### DIFF
--- a/module/evdi_encoder.c
+++ b/module/evdi_encoder.c
@@ -54,7 +54,7 @@ struct drm_encoder *evdi_encoder_init(struct drm_device *dev)
 		goto err;
 
 	ret = drm_encoder_init(dev, encoder, &evdi_enc_funcs,
-			       DRM_MODE_ENCODER_TMDS, dev_name(dev->dev));
+			       DRM_MODE_ENCODER_TMDS, "%s", dev_name(dev->dev));
 	if (ret) {
 		EVDI_ERROR("Failed to initialize encoder: %d\n", ret);
 		goto err_encoder;


### PR DESCRIPTION
When building against the 6.1.6 kernel (maybe others..) the name field in drm_encodeer_init() is checked as a printf format string.  This causes a fatal error:

2023/01/24 11:37:04 akmodsbuild: /tmp/akmodsbuild.N6DUGkQn/BUILD/evdi-bdc258b25df4d00f222fde0e3c5003bf88ef17b5/_kmod_build_6.1.6-100.fc36.x86_64/evdi_encoder.c:57:32: error: format not a string literal and no format arguments [-Werror=format-security]
2023/01/24 11:37:04 akmodsbuild: 57 |                                DRM_MODE_ENCODER_TMDS, dev_name(dev->dev));
2023/01/24 11:37:04 akmodsbuild: |                                ^~~~~~~~~~~~~~~~~~~~~
2023/01/24 11:37:04 akmodsbuild: cc1: some warnings being treated as errors
2023/01/24 11:37:04 akmodsbuild: make[1]: *** [scripts/Makefile.build:250: /tmp/akmodsbuild.N6DUGkQn/BUILD/evdi-bdc258b25df4d00f222fde0e3c5003bf88ef17b5/_kmod_build_6.1.6-100.fc36.x86_64/evdi_encoder.o] Error 1

This change makes name be a "%s" format string with dev_name(dev->dev) as the sole following arg.