### PR TITLE
Add support for kernel 6.2

### DIFF
--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -405,7 +405,11 @@ static int evdifb_create(struct drm_fb_helper *helper,
 	fb = &efbdev->efb.base;
 
 	efbdev->helper.fb = fb;
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+	efbdev->helper.info = info;
+#else
 	efbdev->helper.fbdev = info;
+#endif
 
 	strcpy(info->fix.id, "evdidrmfb");
 
@@ -459,8 +463,13 @@ static void evdi_fbdev_destroy(__always_unused struct drm_device *dev,
 {
 	struct fb_info *info;
 
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+	if (efbdev->helper.info) {
+		info = efbdev->helper.info;
+#else
 	if (efbdev->helper.fbdev) {
 		info = efbdev->helper.fbdev;
+#endif
 		unregister_framebuffer(info);
 		if (info->cmap.len)
 			fb_dealloc_cmap(&info->cmap);
@@ -537,10 +546,17 @@ void evdi_fbdev_unplug(struct drm_device *dev)
 		return;
 
 	efbdev = evdi->fbdev;
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+	if (efbdev->helper.info) {
+		struct fb_info *info;
+
+		info = efbdev->helper.info;
+#else
 	if (efbdev->helper.fbdev) {
 		struct fb_info *info;
 
 		info = efbdev->helper.fbdev;
+#endif
 #if KERNEL_VERSION(5, 6, 0) <= LINUX_VERSION_CODE || defined(EL8)
 		unregister_framebuffer(info);
 #else


### PR DESCRIPTION
Original patch was suggested by Crashdummyy.

Since commit 9877d8f6bc374912b08dfe862cddbb78b395a5ef
in linux kernel
feild fbdev has been renamed to info in struct drm_fb_helper.

Fixes: https://github.com/DisplayLink/evdi/issues/394
Fixes: https://github.com/DisplayLink/evdi/issues/384
Fixes: https://github.com/DisplayLink/evdi/issues/402
Signed-off-by: listout <listout@protonmail.com>

Before submitting the PR please make sure you have run *ci* scripts:
  * `./ci/build_against_kernel` (see `--help` for all options)
    We need backward compatibility and this script is a handy way of testing
    build compliance with many kernel versions.
  * `./ci/run_style_check`
    We want to be as style compliant as possible. Again, this is a handy way of
    checking it.

If you have more than one change consider creating separate PRs for them; it
will make the review process much easier. Also provide some description (links
to source code or mailing list are welcome - this might help to understand the
change).

Thanks for the contribution!
