### PR TITLE
Resolve compile errors for Linux Kernel 6.6

### DIFF
--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -124,9 +124,13 @@ static struct drm_driver driver = {
 
 	.fops = &evdi_driver_fops,
 
+#if KERNEL_VERSION(6, 6, 0) > LINUX_VERSION_CODE
 	.prime_fd_to_handle = drm_gem_prime_fd_to_handle,
+#endif
 	.gem_prime_import = drm_gem_prime_import,
+#if KERNEL_VERSION(6, 6, 0) > LINUX_VERSION_CODE
 	.prime_handle_to_fd = drm_gem_prime_handle_to_fd,
+#endif
 #if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #else
 	.preclose = evdi_driver_preclose,

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -418,7 +418,9 @@ static int evdifb_create(struct drm_fb_helper *helper,
 	info->fix.smem_start = (unsigned long)efbdev->efb.obj->vmapping;
 
 #if KERNEL_VERSION(4, 20, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#ifdef FBINFO_DEFAULT
 	info->flags = FBINFO_DEFAULT;
+#endif
 #else
 	info->flags = FBINFO_DEFAULT | FBINFO_CAN_FORCE_OUTPUT;
 #endif


### PR DESCRIPTION
I am getting compile errors for Linux Kernel 6.6. See #433 and [NixOS/nixpkgs Issue 265868](https://github.com/NixOS/nixpkgs/issues/265868). This PR applies fixes that I think are correct based on the changes made to Linux Kernel 6.6.

Specifically, the changes made in this patch are
1. `drm_gem_prime_fd_to_handle` and `drm_gem_prime_handle_to_fd` are no longer exported as these are the defaults (if I understand correctly), so `.prime_fd_to_handle` and `.prime_handle_to_fd` no longer need to be set.
2. `FBINFO_DEFAULT` is no longer defined as it was defined as `0` and this is the default value (assuming the `info` struct is zero initialised)

I have done limited testing on my system and it seems to work and the CI build against Linux Kernel 6.6 passes.