### PR TITLE
Add switch EL93 to get evdi_fb.c compiled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ all:
 	CXXFLAGS="-I../module -I../library $(FLAGS_CXX) $(CXXFLAGS)" $(MAKE) -C pyevdi $(MFLAGS)
 
 install:
-	$(MAKE) -C module install
+	$(MAKE) -C module install_dkms
 	$(MAKE) -C library install
 	$(MAKE) -C pyevdi install
 
 uninstall:
-	$(MAKE) -C module uninstall
+	$(MAKE) -C module uninstall_dkms
 	$(MAKE) -C library uninstall
 	$(MAKE) -C pyevdi uninstall
 

--- a/module/Makefile
+++ b/module/Makefile
@@ -16,6 +16,11 @@ ifneq (,$(findstring 1, $(EL9)))
 EL9FLAG := -DEL9
 endif
 
+EL93 := $(shell cat /etc/redhat-release 2>/dev/null | grep -c " 9.3" )
+ifneq (,$(findstring 1, $(EL93)))
+EL93FLAG := -DEL93
+endif
+
 Raspbian := $(shell grep -Eic 'raspb(erry|ian)' /proc/cpuinfo /etc/os-release 2>/dev/null )
 ifeq (,$(findstring 0, $(Raspbian)))
 RPIFLAG := -DRPI

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -404,7 +404,7 @@ static int evdifb_create(struct drm_fb_helper *helper,
 	fb = &efbdev->efb.base;
 
 	efbdev->helper.fb = fb;
-#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE || defined(EL93)
 	efbdev->helper.info = info;
 #else
 	efbdev->helper.fbdev = info;
@@ -465,7 +465,7 @@ static void evdi_fbdev_destroy(__always_unused struct drm_device *dev,
 {
 	struct fb_info *info;
 
-#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE || defined(EL93)
 	if (efbdev->helper.info) {
 		info = efbdev->helper.info;
 #else
@@ -502,7 +502,7 @@ int evdi_fbdev_init(struct drm_device *dev)
 		return -ENOMEM;
 
 	evdi->fbdev = efbdev;
-#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE || defined(EL93)
 	drm_fb_helper_prepare(dev, &efbdev->helper, 32, &evdi_fb_helper_funcs);
 #else
 	drm_fb_helper_prepare(dev, &efbdev->helper, &evdi_fb_helper_funcs);
@@ -523,7 +523,7 @@ int evdi_fbdev_init(struct drm_device *dev)
 	drm_fb_helper_single_add_all_connectors(&efbdev->helper);
 #endif
 
-#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE || defined(EL93)
 	ret = drm_fb_helper_initial_config(&efbdev->helper);
 #else
 	ret = drm_fb_helper_initial_config(&efbdev->helper, 32);
@@ -557,7 +557,7 @@ void evdi_fbdev_unplug(struct drm_device *dev)
 		return;
 
 	efbdev = evdi->fbdev;
-#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE || defined(EL93)
 	if (efbdev->helper.info) {
 		struct fb_info *info;
 

--- a/pyevdi/Card.cpp
+++ b/pyevdi/Card.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 DisplayLink (UK) Ltd.
+#include <functional.h>
 #include "../library/evdi_lib.h"
 #include <pybind11/pybind11.h>
 #include "Card.h"


### PR DESCRIPTION
To compile module/evdi_fb.c in AlmaLinux 9.3 a new (code) switch is required (EL93). This is probably also applicable to RHEL 9.3 (didn't check).