### PR TITLE
Adjusting compile to account for newer EL 8 and EL 9 kernels

### DIFF
--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -12,12 +12,12 @@
  */
 
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 #include <drm/drm_ioctl.h>
 #include <drm/drm_file.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_vblank.h>
-#elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -404,7 +404,7 @@ static int evdifb_create(struct drm_fb_helper *helper,
 	fb = &efbdev->efb.base;
 
 	efbdev->helper.fb = fb;
-#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 	efbdev->helper.info = info;
 #else
 	efbdev->helper.fbdev = info;
@@ -465,7 +465,7 @@ static void evdi_fbdev_destroy(__always_unused struct drm_device *dev,
 {
 	struct fb_info *info;
 
-#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 	if (efbdev->helper.info) {
 		info = efbdev->helper.info;
 #else
@@ -502,7 +502,7 @@ int evdi_fbdev_init(struct drm_device *dev)
 		return -ENOMEM;
 
 	evdi->fbdev = efbdev;
-#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 	drm_fb_helper_prepare(dev, &efbdev->helper, 32, &evdi_fb_helper_funcs);
 #else
 	drm_fb_helper_prepare(dev, &efbdev->helper, &evdi_fb_helper_funcs);
@@ -523,7 +523,7 @@ int evdi_fbdev_init(struct drm_device *dev)
 	drm_fb_helper_single_add_all_connectors(&efbdev->helper);
 #endif
 
-#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 	ret = drm_fb_helper_initial_config(&efbdev->helper);
 #else
 	ret = drm_fb_helper_initial_config(&efbdev->helper, 32);
@@ -557,7 +557,7 @@ void evdi_fbdev_unplug(struct drm_device *dev)
 		return;
 
 	efbdev = evdi->fbdev;
-#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 	if (efbdev->helper.info) {
 		struct fb_info *info;
 

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -14,10 +14,10 @@
 #elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 #include <linux/dma-buf-map.h>
 #endif
-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 #include <drm/drm_prime.h>
 #include <drm/drm_file.h>
-#elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
 #else
 #include <drm/drmP.h>
 #endif
@@ -183,6 +183,7 @@ int evdi_drm_gem_mmap(struct file *filp, struct vm_area_struct *vma)
 	if (ret)
 		return ret;
 
+/* Some VMA modifier function patches present in 6.3 were reverted in EL kernels */
 #if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
 	vm_flags_mod(vma, VM_MIXEDMAP, VM_PFNMAP);
 #else
@@ -291,7 +292,7 @@ int evdi_gem_vmap(struct evdi_gem_object *obj)
 	if (evdi_drm_gem_object_use_import_attach(&obj->base)) {
 #if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 		struct iosys_map map = IOSYS_MAP_INIT_VADDR(NULL);
-#elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 		struct dma_buf_map map = DMA_BUF_MAP_INIT_VADDR(NULL);
 #endif
 
@@ -332,7 +333,7 @@ void evdi_gem_vunmap(struct evdi_gem_object *obj)
 
 		dma_buf_vunmap(obj->base.import_attach->dmabuf, &map);
 
-#elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 		struct dma_buf_map map;
 
 		if (obj->vmap_is_iomem)

--- a/module/evdi_ioc32.c
+++ b/module/evdi_ioc32.c
@@ -22,9 +22,9 @@
 #include <linux/compat.h>
 
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 #include <drm/drm_ioctl.h>
-#elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
 #else
 #include <drm/drmP.h>
 #endif

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -12,10 +12,10 @@
  */
 
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 #include <drm/drm_vblank.h>
 #include <drm/drm_damage_helper.h>
-#elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#elif KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
 #include <drm/drm_damage_helper.h>
 #else
 #include <drm/drmP.h>

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -10,11 +10,11 @@
 #include "linux/thread_info.h"
 #include "linux/mm.h"
 #include <linux/version.h>
-#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+#if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 #include <drm/drm_file.h>
 #include <drm/drm_vblank.h>
 #include <drm/drm_ioctl.h>
-#elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#elif KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE
 #else
 #include <drm/drmP.h>
 #endif


### PR DESCRIPTION
These kernels have DRM changes from kernel 6.3 backported to them. The specific enterprise linux versions are 9.3 and 8.9.
