### PR TITLE
vm_insert_page() return code -EBUSY should not convert to VM_FAULT_SI…

### DIFF
--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -219,6 +219,7 @@ int evdi_gem_fault(struct vm_fault *vmf)
 	case -EAGAIN:
 	case 0:
 	case -ERESTARTSYS:
+	case -EBUSY:
 		return VM_FAULT_NOPAGE;
 	case -ENOMEM:
 		return VM_FAULT_OOM;


### PR DESCRIPTION
…GBUS.

Fixes #444 

VM_FAULT_NOPAGE seems to be correct rc in case of -EBUSY. Can be seen here:
[https://elixir.bootlin.com/linux/v6.5/source/include/linux/mm.h#L3375](url)