### PR TITLE
Fix compile error for linux 6.10.4

### DIFF
--- a/module/evdi_platform_dev.c
+++ b/module/evdi_platform_dev.c
@@ -85,7 +85,7 @@ err_free:
 	return PTR_ERR_OR_ZERO(dev);
 }
 
-#if KERNEL_VERSION(6, 10, 0) >= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 10, 4) >= LINUX_VERSION_CODE
 int evdi_platform_device_remove(struct platform_device *pdev)
 #else
 void evdi_platform_device_remove(struct platform_device *pdev)
@@ -97,7 +97,7 @@ void evdi_platform_device_remove(struct platform_device *pdev)
 
 	evdi_drm_device_remove(data->drm_dev);
 	kfree(data);
-#if KERNEL_VERSION(6, 10, 0) >= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 10, 4) >= LINUX_VERSION_CODE
 	return 0;
 #endif
 }

--- a/module/evdi_platform_dev.h
+++ b/module/evdi_platform_dev.h
@@ -32,7 +32,7 @@ struct platform_device *evdi_platform_dev_create(struct platform_device_info *in
 void evdi_platform_dev_destroy(struct platform_device *dev);
 
 int evdi_platform_device_probe(struct platform_device *pdev);
-#if KERNEL_VERSION(6, 10, 0) >= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 10, 4) >= LINUX_VERSION_CODE
 int evdi_platform_device_remove(struct platform_device *pdev);
 #else
 void evdi_platform_device_remove(struct platform_device *pdev);


### PR DESCRIPTION
Commit 76505e9 adds support for the change to the `platform_driver` struct.

However, the change to modify `.remove`  has only been added in v6.11-rc1 See [commit in platform_device.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/include/linux/platform_device.h?h=v6.11-rc3&id=0edb555a65d1ef047a9805051c36922b52a38a9d)

Closes #481