### PR TITLE
Fix compilation error with kernel 6.12

### DIFF
--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -73,6 +73,10 @@ static const struct file_operations evdi_driver_fops = {
 #endif
 
 	.llseek = noop_llseek,
+
+#if defined(FOP_UNSIGNED_OFFSET)
+	.fop_flags = FOP_UNSIGNED_OFFSET,
+#endif
 };
 
 #if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE || defined(EL8)


### PR DESCRIPTION
This PR fixes the following issue: https://github.com/DisplayLink/evdi/issues/495

Tested on kernel 6.12 using latest Arch packages. Also tested against kernel 6.11.9 and latest TLS 6.6.63 for backwards compatibility.