### PR TITLE
Fix building on latest EL9 kernels

### DIFF
--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -34,7 +34,7 @@
 #include "evdi_debug.h"
 #include "evdi_drm.h"
 
-#if KERNEL_VERSION(6, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#if KERNEL_VERSION(6, 8, 0) <= LINUX_VERSION_CODE || defined(EL9)
 #define EVDI_DRM_UNLOCKED 0
 #else
 #define EVDI_DRM_UNLOCKED DRM_UNLOCKED
@@ -126,7 +126,7 @@ static struct drm_driver driver = {
 	.fops = &evdi_driver_fops,
 
 	.gem_prime_import = drm_gem_prime_import,
-#if KERNEL_VERSION(6, 6, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 6, 0) <= LINUX_VERSION_CODE || defined(EL9)
 #else
 	.prime_fd_to_handle = drm_gem_prime_fd_to_handle,
 	.prime_handle_to_fd = drm_gem_prime_handle_to_fd,

--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -18,7 +18,7 @@
 #include <linux/mutex.h>
 #include <linux/device.h>
 #include <linux/i2c.h>
-#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+#if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <drm/drm_drv.h>
 #include <drm/drm_fourcc.h>
 #include <drm/drm_ioctl.h>

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -417,7 +417,7 @@ static int evdifb_create(struct drm_fb_helper *helper,
 	info->fix.smem_len = size;
 	info->fix.smem_start = (unsigned long)efbdev->efb.obj->vmapping;
 
-#if KERNEL_VERSION(6, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 4, 0) <= LINUX_VERSION_CODE || defined(EL9)
 #elif KERNEL_VERSION(4, 20, 0) <= LINUX_VERSION_CODE || defined(EL8)
 	info->flags = FBINFO_DEFAULT;
 #else

--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -184,8 +184,8 @@ int evdi_drm_gem_mmap(struct file *filp, struct vm_area_struct *vma)
 	if (ret)
 		return ret;
 
-/* Some VMA modifier function patches present in 6.3 were reverted in EL kernels */
-#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+/* Some VMA modifier function patches present in 6.3 were reverted in EL8 kernels */
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE || defined(EL9)
 	vm_flags_mod(vma, VM_MIXEDMAP, VM_PFNMAP);
 #else
 	vma->vm_flags &= ~VM_PFNMAP;

--- a/module/evdi_i2c.c
+++ b/module/evdi_i2c.c
@@ -40,7 +40,7 @@ int evdi_i2c_add(struct i2c_adapter *adapter, struct device *parent,
 	void *ddev)
 {
 	adapter->owner  = THIS_MODULE;
-#if KERNEL_VERSION(6, 8, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#if KERNEL_VERSION(6, 8, 0) <= LINUX_VERSION_CODE || defined(EL9)
 #else
 	adapter->class  = I2C_CLASS_DDC;
 #endif

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -504,7 +504,7 @@ static int evdi_crtc_init(struct drm_device *dev)
 
 static const struct drm_mode_config_funcs evdi_mode_funcs = {
 	.fb_create = evdi_fb_user_fb_create,
-#if KERNEL_VERSION(6, 11, 0) < LINUX_VERSION_CODE || defined(EL8)
+#if KERNEL_VERSION(6, 11, 0) < LINUX_VERSION_CODE || defined(EL9)
 #else
 	.output_poll_changed = NULL,
 #endif

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -31,10 +31,11 @@
 
 #include <linux/dma-buf.h>
 #include <linux/vt_kern.h>
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 #include <linux/compiler_attributes.h>
 #endif
 
+/* Import of DMA_BUF namespace was reverted in EL8 */
 #if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
 MODULE_IMPORT_NS(DMA_BUF);
 #endif
@@ -718,7 +719,7 @@ void evdi_painter_dpms_notify(struct evdi_painter *painter, int mode)
 	switch (mode) {
 	case DRM_MODE_DPMS_ON:
 		painter->fg_console = fg_console;
-#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE || defined(EL8)
 		fallthrough;
 #else
 #endif

--- a/module/evdi_platform_dev.c
+++ b/module/evdi_platform_dev.c
@@ -85,6 +85,7 @@ err_free:
 	return PTR_ERR_OR_ZERO(dev);
 }
 
+/* EL9 kernel removed the callback that was returning void  */
 #if KERNEL_VERSION(6, 11, 0) <= LINUX_VERSION_CODE
 void evdi_platform_device_remove(struct platform_device *pdev)
 #else

--- a/module/evdi_platform_dev.h
+++ b/module/evdi_platform_dev.h
@@ -32,6 +32,7 @@ struct platform_device *evdi_platform_dev_create(struct platform_device_info *in
 void evdi_platform_dev_destroy(struct platform_device *dev);
 
 int evdi_platform_device_probe(struct platform_device *pdev);
+/* EL9 kernel removed the callback that was returning void  */
 #if KERNEL_VERSION(6, 11, 0) <= LINUX_VERSION_CODE
 void evdi_platform_device_remove(struct platform_device *pdev);
 #else


### PR DESCRIPTION
This commit fixes building evdi on the latest EL9 kernels which have backported changes from the 6.11 kernel.

While going through the code, made some other adjustments for what applies to EL8 and what doesn't.