### PR TITLE
Fix building on kernels prior to 6.13

### DIFF
--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -29,6 +29,8 @@
 #include <linux/vmalloc.h>
 
 #if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+MODULE_IMPORT_NS(DMA_BUF);
+#elif KERNEL_VERSION(6, 13, 0) <= LINUX_VERSION_CODE
 MODULE_IMPORT_NS("DMA_BUF");
 #endif
 

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -37,6 +37,8 @@
 
 /* Import of DMA_BUF namespace was reverted in EL8 */
 #if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL9)
+MODULE_IMPORT_NS(DMA_BUF);
+#elif KERNEL_VERSION(6, 13, 0) <= LINUX_VERSION_CODE
 MODULE_IMPORT_NS("DMA_BUF");
 #endif
 


### PR DESCRIPTION
The commit 3651b6debf631febf470106d43199d7fbd7bfd56 causes an issue for kernels prior to 6.13-rc3.
