### PR TITLE
Fix building on kernel 6.14

### DIFF
--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -147,7 +147,9 @@ static struct drm_driver driver = {
 
 	.name = DRIVER_NAME,
 	.desc = DRIVER_DESC,
+#if KERNEL_VERSION(6, 14, 0) > LINUX_VERSION_CODE
 	.date = DRIVER_DATE,
+#endif
 	.major = DRIVER_MAJOR,
 	.minor = DRIVER_MINOR,
 	.patchlevel = DRIVER_PATCH,


### PR DESCRIPTION
In Linux 6.14-rc1 the field 'date' has been removed from the struct drm_driver. See upstream commit:

cb2e1c2136f716 drm: remove driver date from struct drm_driver and all drivers

This causes the following compile time error when compiling against 6.14 kernel:

```
evdi_drm_drv.c:150:10: error: ‘struct drm_driver’ has no member named ‘date’
  150 |         .date = DRIVER_DATE,
      |          ^~~~
```

Adjust the initialization of the struct drm_driver accordingly.
