### PR TITLE
Fix heap-buffer-overflow in process_name by allocating space for null terminator

### DIFF
--- a/library/evdi_procfs.c
+++ b/library/evdi_procfs.c
@@ -38,7 +38,7 @@ static void close_folder(FILE *pf)
 
 static char *process_name(FILE *pf)
 {
-	int Xorg_name_len = 6;
+	int Xorg_name_len = 7;	// 6 + 1 for null terminator
 	char *name = (char *)malloc(Xorg_name_len * sizeof(char));
 
 	fscanf(pf, "%*s");


### PR DESCRIPTION
This PR fixes a heap-buffer-overflow in process_name, where only 6 bytes were allocated for a string that requires 7 (to include the null terminator). The issue was detected by compiling with -fsanitize=address and then running the code.

As requested, ci scripts were run. Builds were successful for kernel versions 6.14 - 6.0 and 5.19 - 5.17, but failed for 5.16 due to the following error

```
subcmd-util.h: In function ‘xrealloc’:
subcmd-util.h:58:31: error: pointer ‘ptr’ may be used after ‘realloc’ [-Werror=use-after-free]
   58 |                         ret = realloc(ptr, 1);
```

This appears unrelated to the change, which only updates a single malloc size by one byte.
