### PR TITLE
Fix build for kernel v6.17-rc1

### DIFF
--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -109,6 +109,9 @@ int evdifb_create(struct drm_fb_helper *helper,
 struct drm_framebuffer *evdi_fb_user_fb_create(
 				struct drm_device *dev,
 				struct drm_file *file,
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE
+				const struct drm_format_info *info,
+#endif
 				const struct drm_mode_fb_cmd2 *mode_cmd);
 
 int evdi_dumb_create(struct drm_file *file_priv,


### PR DESCRIPTION
Following v6.17-rc1 commits changes DRM APIs:
* commit 81112eaac559c ("drm: Pass the format info to .fb_create()")
* commit a34cc7bf10342 ("drm: Allow the caller to pass in the format info to drm_helper_mode_fill_fb_struct()")
* commit 04a5889cf75aa ("drm/gem: Pass along the format info from .fb_create() to drm_helper_mode_fill_fb_struct()")

Bug-Ubuntu: https://bugs.launchpad.net/bugs/2120459