### PR TITLE
Make /etc/os-release optional

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -6,10 +6,14 @@
 # more details.
 #
 
-include /etc/os-release
+ifneq ($(wildcard /etc/os-release),)
+-include /etc/os-release
+endif
 
 ifneq (,$(findstring rhel,$(ID_LIKE)))
-ELFLAG := -DEL$(VERSION_ID)
+  ifneq (,$(VERSION_ID))
+    ELFLAG := -DEL$(VERSION_ID)
+  endif
 endif
 
 Raspbian := $(shell grep -Eic 'raspb(erry|ian)' /proc/cpuinfo /etc/os-release 2>/dev/null )


### PR DESCRIPTION
This change makes the /etc/os-release include in the Makefile optional. Without it, the build fails on systems that don't have it, e.g. minimalistic chroot environments where evdi is built as in-tree module.