### PR TITLE
 Drop drm_fb_helper_debug_enter and drm_fb_helper_debug_leave ( Support Kernel 7.0.0 )

### DIFF
--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -213,8 +213,11 @@ static const struct fb_ops evdifb_ops = {
 	.fb_pan_display = drm_fb_helper_pan_display,
 	.fb_blank = drm_fb_helper_blank,
 	.fb_setcmap = drm_fb_helper_setcmap,
+#if KERNEL_VERSION(7, 0, 0) <= LINUX_VERSION_CODE
+#else
 	.fb_debug_enter = drm_fb_helper_debug_enter,
 	.fb_debug_leave = drm_fb_helper_debug_leave,
+#endif
 	.fb_mmap = evdi_fb_mmap,
 	.fb_open = evdi_fb_open,
 	.fb_release = evdi_fb_release,


### PR DESCRIPTION
Evdi cant be built on kernel 7.0.

```
evdi_fb.c:216:20: error: use of undeclared identifier 'drm_fb_helper_debug_enter'
  216 |         .fb_debug_enter = drm_fb_helper_debug_enter,
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
evdi_fb.c:217:20: error: use of undeclared identifier 'drm_fb_helper_debug_leave'
  217 |         .fb_debug_leave = drm_fb_helper_debug_leave,
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

Looks like they have been dropped this helper entirely as its supposedly broken for a long time now and no one uses it anymore.
( https://lore.freedesktop.org/nouveau/20251125130634.1080966-5-tzimmermann@suse.de/t/#u )