### PR TITLE
Fix asahi linux (apple silicon) compile error

### DIFF
--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -173,7 +173,7 @@ static void collapse_dirty_rects(struct drm_clip_rect *rects, int *count)
 	*count = 1;
 }
 
-#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+#if (KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)) && defined(CONFIG_X86)
 static int copy_primary_pixels_on_xe(struct evdi_framebuffer *efb,
 			       char __user *buffer,
 			       int buf_byte_stride,
@@ -218,7 +218,7 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 
 	EVDI_CHECKPT();
 
-#if KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
+#if (KERNEL_VERSION(5, 18, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)) && defined(CONFIG_X86)
 	if (efb->is_from_xe)
 		return copy_primary_pixels_on_xe(efb, buffer, buf_byte_stride, max_x, max_y);
 #endif


### PR DESCRIPTION
Fixes compilation error on asahi linux, and probably other arm distros. 

Tested on MBP 2021 (14") M1 Pro - Fedora 42 Asahi
6.18.10-402.asahi.fc42.aarch64+16k