### PR TITLE
include pybind common macros first in pyevdi

### DIFF
--- a/pyevdi/Card.cpp
+++ b/pyevdi/Card.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2022 DisplayLink (UK) Ltd.
+#include <pybind11/detail/common.h>
+
 #include <sstream>
 
 #include "../library/evdi_lib.h"

--- a/pyevdi/PyEvdi.cpp
+++ b/pyevdi/PyEvdi.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2022 DisplayLink (UK) Ltd.
+#include <pybind11/detail/common.h>
+
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
libstdlibc++ and pybind11 POSIX versions may differ, leading to redefininition errors. This is the case with GCC/libstdc++ 15.2.1 and Python 3.14.

This PR sets the POSIX version in pybind11 as the leading one. This is achieved by including the pybind11 detail/common (where macros are defined) header first.

Extra information on the error:

- PyEvdi.cpp includes cstdarg, which defines _POSIX_C_SOURCE/_XOPEN_SOURCE to 202405L/800, respectively
- PyEvdi.cpp includes pybind11/functional, which has no guards around _POSIX_C_SOURCE/_XOPEN_SOURCE and tries to redefine it, leading to errors if versions do not match.

```
In file included from /usr/include/python3.14/Python.h:14,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/conduit/wrap_include_python_h.h:44,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/detail/common.h:12,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/attr.h:13,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/detail/class.h:12,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/pybind11.h:12,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/functional.h:12,
                 from PyEvdi.cpp:5:
/usr/include/python3.14/pyconfig.h:2007:9: fout: ‘_POSIX_C_SOURCE’ redefined [-Werror]
 2007 | #define _POSIX_C_SOURCE 200809L
      |         ^~~~~~~~~~~~~~~
In file included from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/os_defines.h:39,
                 from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/c++config.h:727,
                 from /usr/include/c++/15.2.1/cstdarg:47,
                 from PyEvdi.cpp:2:
/usr/include/features.h:319:10: note: dit is de plaats van de eerdere definitie
  319 | # define _POSIX_C_SOURCE        202405L
      |          ^~~~~~~~~~~~~~~
/usr/include/python3.14/pyconfig.h:2043:9: fout: ‘_XOPEN_SOURCE’ redefined [-Werror]
 2043 | #define _XOPEN_SOURCE 700
      |         ^~~~~~~~~~~~~
/usr/include/features.h:234:10: note: dit is de plaats van de eerdere definitie
  234 | # define _XOPEN_SOURCE  800
      |          ^~~~~~~~~~~~~
In file included from /usr/include/python3.14/Python.h:14,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/conduit/wrap_include_python_h.h:44,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/detail/common.h:12,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/attr.h:13,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/detail/class.h:12,
                 from /usr/lib/python3.14/site-packages/pybind11/include/pybind11/pybind11.h:12,
                 from Card.h:5,
                 from Card.cpp:6:
/usr/include/python3.14/pyconfig.h:2007:9: fout: ‘_POSIX_C_SOURCE’ redefined [-Werror]
 2007 | #define _POSIX_C_SOURCE 200809L
      |         ^~~~~~~~~~~~~~~
In file included from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/os_defines.h:39,
                 from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/c++config.h:727,
                 from /usr/include/c++/15.2.1/bits/requires_hosted.h:31,
                 from /usr/include/c++/15.2.1/sstream:40,
                 from Card.cpp:2:
/usr/include/features.h:319:10: note: dit is de plaats van de eerdere definitie
  319 | # define _POSIX_C_SOURCE        202405L
      |          ^~~~~~~~~~~~~~~
/usr/include/python3.14/pyconfig.h:2043:9: fout: ‘_XOPEN_SOURCE’ redefined [-Werror]
 2043 | #define _XOPEN_SOURCE 700
      |         ^~~~~~~~~~~~~
/usr/include/features.h:234:10: note: dit is de plaats van de eerdere definitie
  234 | # define _XOPEN_SOURCE  800
  ```