### PR TITLE
Fix module build on CentOS 9 and 10

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -12,6 +12,10 @@ ifneq (,$(findstring rhel,$(ID_LIKE)))
 ELFLAG := -DEL$(shell echo $(VERSION_ID) | cut -d. -f1)
 endif
 
+ifneq (,$(findstring centos,$(ID)))
+CENTOSFLAG := -DCENTOS$(VERSION_ID)
+endif
+
 Raspbian := $(shell grep -Eic 'raspb(erry|ian)' /proc/cpuinfo /etc/os-release 2>/dev/null )
 ifeq (,$(findstring 0, $(Raspbian)))
 RPIFLAG := -DRPI
@@ -23,7 +27,7 @@ ifneq ($(DKMS_BUILD),)
 
 KERN_DIR := /lib/modules/$(KERNELRELEASE)/build
 
-ccflags-y := -Iinclude/uapi/drm -Iinclude/drm $(ELFLAG) $(RPIFLAG)
+ccflags-y := -Iinclude/uapi/drm -Iinclude/drm $(ELFLAG) $(CENTOSFLAG) $(RPIFLAG)
 evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o evdi_i2c.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 obj-m := evdi.o
@@ -45,7 +49,7 @@ ifneq ($(KERNELRELEASE),)
 
 # inside kbuild
 # Note: this can be removed once it is in kernel tree and Kconfig is properly used
-ccflags-y := -isystem include/uapi/drm $(CFLAGS) $(ELFLAG) $(RPIFLAG)
+ccflags-y := -isystem include/uapi/drm $(CFLAGS) $(ELFLAG) $(CENTOSFLAG) $(RPIFLAG)
 evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o evdi_i2c.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 CONFIG_DRM_EVDI ?= m

--- a/module/Makefile
+++ b/module/Makefile
@@ -13,7 +13,7 @@ ELFLAG := -DEL$(shell echo $(VERSION_ID) | cut -d. -f1)
 endif
 
 ifneq (,$(findstring centos,$(ID)))
-CENTOSFLAG := -DCENTOS$(VERSION_ID)
+CENTOSFLAG := -DCENTOS$(shell echo $(VERSION_ID) | cut -d. -f1)
 endif
 
 Raspbian := $(shell grep -Eic 'raspb(erry|ian)' /proc/cpuinfo /etc/os-release 2>/dev/null )

--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -102,7 +102,7 @@ long evdi_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long arg);
 struct drm_framebuffer *evdi_fb_user_fb_create(
 				struct drm_device *dev,
 				struct drm_file *file,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
 				const struct drm_format_info *info,
 #endif
 				const struct drm_mode_fb_cmd2 *mode_cmd);

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -203,20 +203,20 @@ static const struct drm_framebuffer_funcs evdifb_funcs = {
 static int
 evdi_framebuffer_init(struct drm_device *dev,
 		      struct evdi_framebuffer *efb,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
 		      const struct drm_format_info *info,
 #endif
 		      const struct drm_mode_fb_cmd2 *mode_cmd,
 		      struct evdi_gem_object *obj)
 {
 	efb->obj = obj;
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
 	if (info == NULL)
 		info = drm_get_format_info(dev, mode_cmd->pixel_format,
 					   mode_cmd->modifier[0]);
 #endif
 	drm_helper_mode_fill_fb_struct(dev, &efb->base,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
 				       info,
 #endif
 				       mode_cmd);
@@ -253,7 +253,7 @@ static bool is_xe_gem(struct dma_buf *dmabuf)
 struct drm_framebuffer *evdi_fb_user_fb_create(
 					struct drm_device *dev,
 					struct drm_file *file,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
 					const struct drm_format_info *info,
 #endif
 					const struct drm_mode_fb_cmd2 *mode_cmd)
@@ -289,7 +289,7 @@ struct drm_framebuffer *evdi_fb_user_fb_create(
 	efb->base.obj[0] = obj;
 
 	ret = evdi_framebuffer_init(dev, efb,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
 				    info,
 #endif
 				    mode_cmd, to_evdi_bo(obj));


### PR DESCRIPTION
The evdi module build fails on CentOS Stream 9 and 10 due to some 6.17 kernel changes being backported. This PR adds a CENTOSFLAG to differentiate from ELFLAG because CentOS Stream runs ahead of the other EL kernels (Rocky Linux, AlmaLinux, RHEL) and they don't have the same changes backported yet.

I suppose when the time comes to add the defined(EL9) and defined(EL10) checks for the 6.17 changes to evdi_drm_drv.h‎ and evdi_fb.c, then the defined(CENTOS9) and defined(CENTOS10) checks can be removed because CentOS Stream 9 and 10 also trigger the EL9 and EL10 flags, respectively. But it wouldn't hurt to leave them either.