### PR TITLE
Fix module build on RHEL

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -8,7 +8,7 @@
 
 include /etc/os-release
 
-ifneq (,$(findstring rhel,$(ID_LIKE)))
+ifneq (,$(findstring rhel,$(ID_LIKE) $(ID)))
 ELFLAG := -DEL$(shell echo $(VERSION_ID) | cut -d. -f1)
 endif
 


### PR DESCRIPTION
This PR ensures that the EL flag is set when building on Red Hat Enterprise Linux so that the build succeeds.