### PR TITLE
Fix module build on EL 9.8 and 10.2

### DIFF
--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -102,7 +102,7 @@ long evdi_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long arg);
 struct drm_framebuffer *evdi_fb_user_fb_create(
 				struct drm_device *dev,
 				struct drm_file *file,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(EL9) || defined(EL10)
 				const struct drm_format_info *info,
 #endif
 				const struct drm_mode_fb_cmd2 *mode_cmd);

--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -203,20 +203,20 @@ static const struct drm_framebuffer_funcs evdifb_funcs = {
 static int
 evdi_framebuffer_init(struct drm_device *dev,
 		      struct evdi_framebuffer *efb,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(EL9) || defined(EL10)
 		      const struct drm_format_info *info,
 #endif
 		      const struct drm_mode_fb_cmd2 *mode_cmd,
 		      struct evdi_gem_object *obj)
 {
 	efb->obj = obj;
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(EL9) || defined(EL10)
 	if (info == NULL)
 		info = drm_get_format_info(dev, mode_cmd->pixel_format,
 					   mode_cmd->modifier[0]);
 #endif
 	drm_helper_mode_fill_fb_struct(dev, &efb->base,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(EL9) || defined(EL10)
 				       info,
 #endif
 				       mode_cmd);
@@ -253,7 +253,7 @@ static bool is_xe_gem(struct dma_buf *dmabuf)
 struct drm_framebuffer *evdi_fb_user_fb_create(
 					struct drm_device *dev,
 					struct drm_file *file,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(EL9) || defined(EL10)
 					const struct drm_format_info *info,
 #endif
 					const struct drm_mode_fb_cmd2 *mode_cmd)
@@ -289,7 +289,7 @@ struct drm_framebuffer *evdi_fb_user_fb_create(
 	efb->base.obj[0] = obj;
 
 	ret = evdi_framebuffer_init(dev, efb,
-#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(CENTOS9) || defined(CENTOS10)
+#if KERNEL_VERSION(6, 17, 0) <= LINUX_VERSION_CODE || defined(EL9) || defined(EL10)
 				    info,
 #endif
 				    mode_cmd, to_evdi_bo(obj));


### PR DESCRIPTION
Now that CentOS Stream kernel changes will be landing in EL (9.8 and 10.2), this PR ensures that the module will build on updated EL systems. Tested on RHEL 9.8 and 10.2 (using Makefile change from #569) as well as on the latest CentOS Stream 9 and 10. I will also test on Rocky Linux 9.8 and 10.2 as well as AlmaLinux 9.8 and 10.2 when they are available.