### PR TITLE
Annotate unused param in evdi_gem_mmap

### DIFF
--- a/module/evdi_gem.c
+++ b/module/evdi_gem.c
@@ -470,7 +470,9 @@ void evdi_gem_free_object(struct drm_gem_object *gem_obj)
  * interface, it expects to do MMAP on the drm fd, like normal
  */
 int evdi_gem_mmap(struct drm_file *file,
-		  struct drm_device *dev, uint32_t handle, uint64_t *offset)
+		  __always_unused struct drm_device *dev,
+		  uint32_t handle,
+		  uint64_t *offset)
 {
 	struct evdi_gem_object *gobj;
 	struct drm_gem_object *obj;


### PR DESCRIPTION
Fixes the build issue mentioned in @WallaceDog's second comment in #573 (https://github.com/DisplayLink/evdi/issues/573#issuecomment-4629757056)

When running make from within the module directory there was no issue (which is how I usually build the module so I didn't see this before), but when running make from within the project's root directory the `-Wextra` caused the build to fail on this unused `dev` param.