### PR TITLE
Fix for kernel v7.2

### DIFF
--- a/module/evdi_fb.c
+++ b/module/evdi_fb.c
@@ -102,7 +102,11 @@ static int evdi_user_framebuffer_dirty(
 	struct evdi_device *evdi = dev->dev_private;
 
 	struct drm_modeset_acquire_ctx ctx;
+#if KERNEL_VERSION(7, 2, 0) <= LINUX_VERSION_CODE
+	struct drm_atomic_commit *state;
+#else
 	struct drm_atomic_state *state;
+#endif
 	struct drm_plane *plane;
 	int ret = 0;
 	unsigned int i;
@@ -116,7 +120,11 @@ static int evdi_user_framebuffer_dirty(
 		 */
 		file_priv ? DRM_MODESET_ACQUIRE_INTERRUPTIBLE :	0);
 
+#if KERNEL_VERSION(7, 2, 0) <= LINUX_VERSION_CODE
+	state = drm_atomic_commit_alloc(fb->dev);
+#else
 	state = drm_atomic_state_alloc(fb->dev);
+#endif
 	if (!state) {
 		ret = -ENOMEM;
 		goto out;
@@ -150,14 +158,22 @@ retry:
 
 out:
 	if (ret == -EDEADLK) {
+#if KERNEL_VERSION(7, 2, 0) <= LINUX_VERSION_CODE
+		drm_atomic_commit_clear(state);
+#else
 		drm_atomic_state_clear(state);
+#endif
 		ret = drm_modeset_backoff(&ctx);
 		if (!ret)
 			goto retry;
 	}
 
 	if (state)
+#if KERNEL_VERSION(7, 2, 0) <= LINUX_VERSION_CODE
+		drm_atomic_commit_put(state);
+#else
 		drm_atomic_state_put(state);
+#endif
 
 	drm_modeset_drop_locks(&ctx);
 	drm_modeset_acquire_fini(&ctx);

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -65,10 +65,12 @@ static void evdi_crtc_set_nofb(__always_unused struct drm_crtc *crtc)
 
 static void evdi_crtc_atomic_flush(
 	struct drm_crtc *crtc
-#if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE || defined(RPI) || defined(EL8)
+#if KERNEL_VERSION(7, 2, 0) <= LINUX_VERSION_CODE
+	, struct drm_atomic_commit *state
+#elif KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE || defined(RPI) || defined(EL8)
 	, struct drm_atomic_state *state
 #else
-	, __always_unused struct drm_crtc_state *old_state
+	, __always_unused struct drm_crtc_commit *old_state
 #endif
 	)
 {
@@ -218,10 +220,12 @@ static const struct drm_crtc_funcs evdi_crtc_funcs = {
 };
 
 static void evdi_plane_atomic_update(struct drm_plane *plane,
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#if KERNEL_VERSION(7, 2, 0) <= LINUX_VERSION_CODE
+				     struct drm_atomic_commit *atom_state
+#elif KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 				     struct drm_atomic_state *atom_state
 #else
-				     struct drm_plane_state *old_state
+				     struct drm_plane_commit *old_state
 #endif
 		)
 {
@@ -316,7 +320,9 @@ static void evdi_cursor_atomic_get_rect(struct drm_clip_rect *rect,
 }
 
 static void evdi_cursor_atomic_update(struct drm_plane *plane,
-#if KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
+#if KERNEL_VERSION(7, 2, 0) <= LINUX_VERSION_CODE
+				     struct drm_atomic_commit *atom_state
+#elif KERNEL_VERSION(5, 13, 0) <= LINUX_VERSION_CODE || defined(EL8)
 				     struct drm_atomic_state *atom_state
 #else
 				     struct drm_plane_state *old_state


### PR DESCRIPTION
This renames **drm_atomic_state** to **drm_atomic_commit** has it was merged in v7.2 (https://github.com/torvalds/linux/commit/5164f7e7ff8ec7d41065d3862630c2ba09854328)