### PR TITLE
Add software GAMMA_LUT/CTM color management on the CRTC

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -36,7 +36,7 @@ ifneq ($(DKMS_BUILD),)
 KERN_DIR := /lib/modules/$(KERNELRELEASE)/build
 
 ccflags-y := -Iinclude/uapi/drm -Iinclude/drm
-evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o evdi_i2c.o
+evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_color.o evdi_debug.o evdi_i2c.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 obj-m := evdi.o
 $(eval $(call evdi_conftest))
@@ -59,7 +59,7 @@ ifneq ($(KERNELRELEASE),)
 # inside kbuild
 # Note: this can be removed once it is in kernel tree and Kconfig is properly used
 ccflags-y := -isystem include/uapi/drm $(CFLAGS)
-evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o evdi_i2c.o
+evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_color.o evdi_debug.o evdi_i2c.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 CONFIG_DRM_EVDI ?= m
 obj-$(CONFIG_DRM_EVDI) := evdi.o

--- a/module/evdi_color.c
+++ b/module/evdi_color.c
@@ -139,9 +139,14 @@ static s64 evdi_color_apply_ctm_channel(const struct evdi_color_data *snapshot,
 void evdi_color_transform_apply_row(const struct evdi_color_data *snapshot,
 				     void *row, int width_px, bool swap_rb)
 {
+	/*
+	 * XRGB8888/ARGB8888 ("x:R:G:B" MSB-to-LSB, little endian per
+	 * drm_fourcc.h) store B at byte 0 and R at byte 2; XBGR8888/
+	 * ABGR8888 swap that. G (byte 1) and X/alpha (byte 3) never move.
+	 */
 	u8 *px = row;
-	const int r_idx = swap_rb ? 2 : 0;
-	const int b_idx = swap_rb ? 0 : 2;
+	const int r_idx = swap_rb ? 0 : 2;
+	const int b_idx = swap_rb ? 2 : 0;
 	int i;
 
 	if (!snapshot->active)

--- a/module/evdi_color.c
+++ b/module/evdi_color.c
@@ -8,21 +8,24 @@
  */
 
 #include <linux/kernel.h>
+#include <linux/list.h>
 #include <linux/minmax.h>
+#include <linux/mutex.h>
 #include <linux/slab.h>
+#include <linux/string.h>
+#include <linux/vmalloc.h>
 #include <drm/drm_color_mgmt.h>
 #include <drm/drm_crtc.h>
 #include <drm/drm_fixed.h>
 
 #include "evdi_color.h"
+#include "evdi_debug.h"
+#include "evdi_drm_drv.h"
+#include "evdi_params.h"
 
-/*
- * struct drm_color_ctm stores each entry as S31.32 sign-magnitude (bit 63
- * is the sign, bits 0-62 are the unsigned value) rather than the two's
- * complement drm_fixed.h (drm_fixp_t) format the drm_fixp_* helpers use.
- * Some newer kernels provide drm_sm2fixp() for this, but it isn't present
- * across the full 4.15+ range evdi supports, so convert it ourselves.
- */
+static LIST_HEAD(evdi_color_list);
+static DEFINE_MUTEX(evdi_color_list_lock);
+
 static s64 evdi_sm2fixp(u64 sm)
 {
 	s64 magnitude = (s64)(sm & ~BIT_ULL(63));
@@ -30,8 +33,64 @@ static s64 evdi_sm2fixp(u64 sm)
 	return (sm & BIT_ULL(63)) ? -magnitude : magnitude;
 }
 
-static void evdi_color_update_gamma(struct evdi_color_data *data,
-				     struct drm_crtc_state *crtc_state)
+static bool evdi_gamma_is_identity(const u8 g[3][EVDI_GAMMA_LUT_SIZE])
+{
+	int c, i;
+
+	for (c = 0; c < 3; ++c)
+		for (i = 0; i < EVDI_GAMMA_LUT_SIZE; ++i)
+			if (g[c][i] != (u8)i)
+				return false;
+	return true;
+}
+
+static bool evdi_ctm_is_identity(const s64 m[3][3])
+{
+	int r, c;
+
+	for (r = 0; r < 3; ++r) {
+		for (c = 0; c < 3; ++c) {
+			s64 expect = (r == c) ? (s64)DRM_FIXED_ONE : 0;
+
+			if (m[r][c] != expect)
+				return false;
+		}
+	}
+	return true;
+}
+
+static bool evdi_ctm_is_diagonal(const s64 m[3][3])
+{
+	int r, c;
+
+	for (r = 0; r < 3; ++r)
+		for (c = 0; c < 3; ++c)
+			if (r != c && m[r][c] != 0)
+				return false;
+	return true;
+}
+
+/* Same diagonal matrix, table form — not a different colour model. */
+static void evdi_fuse_diagonal_ctm_to_gamma(struct evdi_color_data *data)
+{
+	int c, i;
+
+	for (c = 0; c < 3; ++c) {
+		s64 scale = data->ctm[c][c];
+
+		for (i = 0; i < EVDI_GAMMA_LUT_SIZE; ++i) {
+			s64 v = drm_fixp_mul(scale, drm_int2fixp(i));
+
+			data->gamma[c][i] = clamp(drm_fixp2int_round(v), 0, 255);
+		}
+	}
+	data->has_gamma = true;
+	data->has_ctm = false;
+	data->fused_diagonal = true;
+}
+
+static void evdi_color_load_gamma(struct evdi_color_data *data,
+				  struct drm_crtc_state *crtc_state)
 {
 	const struct drm_color_lut *lut;
 	unsigned int lut_len;
@@ -44,19 +103,11 @@ static void evdi_color_update_gamma(struct evdi_color_data *data,
 
 	lut = (const struct drm_color_lut *)crtc_state->gamma_lut->data;
 	lut_len = crtc_state->gamma_lut->length / sizeof(*lut);
-
 	if (lut_len == 0) {
 		data->has_gamma = false;
 		return;
 	}
 
-	/*
-	 * Build a direct 256-entry table indexed by raw 8-bit channel value,
-	 * regardless of the length of the LUT userspace actually uploaded
-	 * (expected to be EVDI_GAMMA_LUT_SIZE, since that's what we advertise
-	 * via drm_mode_crtc_set_gamma_size(), but not all clients necessarily
-	 * respect that hint).
-	 */
 	for (i = 0; i < EVDI_GAMMA_LUT_SIZE; ++i) {
 		s64 idx_fp = drm_fixp_div(drm_int2fixp(i * (lut_len - 1)),
 					   drm_int2fixp(EVDI_GAMMA_LUT_SIZE - 1));
@@ -72,16 +123,14 @@ static void evdi_color_update_gamma(struct evdi_color_data *data,
 			s64 interp = floor_fp + drm_fixp_mul(ceil_fp - floor_fp, frac);
 			int val16 = clamp(drm_fixp2int(interp), 0, 65535);
 
-			/* 16-bit LUT entry -> 8-bit raw pixel channel */
 			data->gamma[c][i] = val16 >> 8;
 		}
 	}
-
 	data->has_gamma = true;
 }
 
-static void evdi_color_update_ctm(struct evdi_color_data *data,
-				   struct drm_crtc_state *crtc_state)
+static void evdi_color_load_ctm(struct evdi_color_data *data,
+				struct drm_crtc_state *crtc_state)
 {
 	const struct drm_color_ctm *ctm;
 	int r, c;
@@ -99,52 +148,180 @@ static void evdi_color_update_ctm(struct evdi_color_data *data,
 	data->has_ctm = true;
 }
 
-void evdi_color_transform_init(struct evdi_color_transform *color)
+static void evdi_color_finalize_locked(struct evdi_color_data *data)
 {
+	data->fused_diagonal = false;
+
+	/* Apply DRM order without degamma: CTM then gamma. */
+	if (data->has_ctm && evdi_ctm_is_identity(data->ctm))
+		data->has_ctm = false;
+	else if (data->has_ctm && evdi_ctm_is_diagonal(data->ctm))
+		evdi_fuse_diagonal_ctm_to_gamma(data);
+
+	if (data->has_gamma && evdi_gamma_is_identity(data->gamma))
+		data->has_gamma = false;
+
+	data->active = data->has_gamma || data->has_ctm;
+}
+
+void evdi_color_transform_init(struct evdi_color_transform *color,
+			       struct drm_device *ddev)
+{
+	memset(color, 0, sizeof(*color));
 	mutex_init(&color->lock);
-	memset(&color->data, 0, sizeof(color->data));
+	color->ddev = ddev;
+	INIT_LIST_HEAD(&color->link);
+
+	mutex_lock(&evdi_color_list_lock);
+	list_add_tail(&color->link, &evdi_color_list);
+	mutex_unlock(&evdi_color_list_lock);
+}
+
+void evdi_color_transform_cleanup(struct evdi_color_transform *color)
+{
+	mutex_lock(&evdi_color_list_lock);
+	list_del_init(&color->link);
+	mutex_unlock(&evdi_color_list_lock);
+	vfree(color->scratch);
+	color->scratch = NULL;
+	color->scratch_bytes = 0;
+	mutex_destroy(&color->lock);
 }
 
 bool evdi_color_transform_update(struct evdi_color_transform *color,
 				 struct drm_crtc_state *crtc_state)
 {
+	struct evdi_color_data before;
+	bool changed;
+
 	if (!crtc_state->color_mgmt_changed)
 		return false;
 
 	mutex_lock(&color->lock);
-	evdi_color_update_gamma(&color->data, crtc_state);
-	evdi_color_update_ctm(&color->data, crtc_state);
-	color->data.active = color->data.has_gamma || color->data.has_ctm;
+	before = color->data;
+	memset(&color->data, 0, sizeof(color->data));
+	evdi_color_load_gamma(&color->data, crtc_state);
+	evdi_color_load_ctm(&color->data, crtc_state);
+	evdi_color_finalize_locked(&color->data);
+	changed = memcmp(&before, &color->data, sizeof(before)) != 0;
 	mutex_unlock(&color->lock);
-	return true;
+	return changed;
 }
 
 bool evdi_color_transform_snapshot(struct evdi_color_transform *color,
-				    struct evdi_color_data *snapshot)
+				   struct evdi_color_data *snapshot)
 {
 	mutex_lock(&color->lock);
 	*snapshot = color->data;
 	mutex_unlock(&color->lock);
-
 	return snapshot->active;
 }
 
+void *evdi_color_get_scratch(struct evdi_color_transform *color, size_t bytes)
+{
+	void *p;
+
+	if (bytes == 0)
+		return NULL;
+
+	mutex_lock(&color->lock);
+	if (color->scratch_bytes >= bytes) {
+		p = color->scratch;
+		mutex_unlock(&color->lock);
+		return p;
+	}
+	vfree(color->scratch);
+	color->scratch = NULL;
+	color->scratch_bytes = 0;
+	mutex_unlock(&color->lock);
+
+	p = vmalloc(bytes);
+	if (!p)
+		return NULL;
+
+	mutex_lock(&color->lock);
+	if (color->scratch_bytes >= bytes) {
+		vfree(p);
+		p = color->scratch;
+	} else {
+		vfree(color->scratch);
+		color->scratch = p;
+		color->scratch_bytes = bytes;
+	}
+	mutex_unlock(&color->lock);
+	return p;
+}
+
 static s64 evdi_color_apply_ctm_channel(const struct evdi_color_data *snapshot,
-					 int row, s64 r, s64 g, s64 b)
+					int row, s64 r, s64 g, s64 b)
 {
 	return drm_fixp_mul(snapshot->ctm[row][0], r) +
 	       drm_fixp_mul(snapshot->ctm[row][1], g) +
 	       drm_fixp_mul(snapshot->ctm[row][2], b);
 }
 
-void evdi_color_transform_apply_row(const struct evdi_color_data *snapshot,
-				     void *row, int width_px, bool swap_rb)
+int evdi_color_format_status(char *buf, size_t size)
 {
-	/*
-	 * XRGB8888/ARGB8888 ("x:R:G:B" MSB-to-LSB, little endian per
-	 * drm_fourcc.h) store B at byte 0 and R at byte 2; XBGR8888/
-	 * ABGR8888 swap that. G (byte 1) and X/alpha (byte 3) never move.
-	 */
+	struct evdi_color_transform *color;
+	int n = 0;
+
+	n += scnprintf(buf + n, size - n,
+		       "color_props=%s (reload module to change)\n"
+		       "# apply only what the compositor programmed; no gamma↔ctm synthesis\n"
+		       "# path=lut|ctm|fused_ctm_lut|off  drm=N is /dev/dri/cardN\n",
+		       evdi_color_props ? evdi_color_props : "both");
+
+	mutex_lock(&evdi_color_list_lock);
+	list_for_each_entry(color, &evdi_color_list, link) {
+		struct evdi_color_data d;
+		int r_s, g_s, b_s;
+		int drm_idx = -1;
+		const char *path;
+
+		mutex_lock(&color->lock);
+		d = color->data;
+		if (color->ddev && color->ddev->primary)
+			drm_idx = color->ddev->primary->index;
+		mutex_unlock(&color->lock);
+
+		if (d.has_gamma) {
+			r_s = d.gamma[0][255];
+			g_s = d.gamma[1][255];
+			b_s = d.gamma[2][255];
+		} else if (d.has_ctm) {
+			r_s = clamp(drm_fixp2int_round(
+				drm_fixp_mul(d.ctm[0][0], drm_int2fixp(255))), 0, 255);
+			g_s = clamp(drm_fixp2int_round(
+				drm_fixp_mul(d.ctm[1][1], drm_int2fixp(255))), 0, 255);
+			b_s = clamp(drm_fixp2int_round(
+				drm_fixp_mul(d.ctm[2][2], drm_int2fixp(255))), 0, 255);
+		} else {
+			r_s = g_s = b_s = 255;
+		}
+
+		if (!d.active)
+			path = "off";
+		else if (d.fused_diagonal)
+			path = "fused_ctm_lut";
+		else if (d.has_ctm)
+			path = "ctm";
+		else if (d.has_gamma)
+			path = "lut";
+		else
+			path = "off";
+
+		n += scnprintf(buf + n, size > n ? size - n : 0,
+			       "drm=%d path=%s active=%d has_gamma=%d has_ctm=%d scales_rgb≈%d/%d/%d\n",
+			       drm_idx, path, d.active, d.has_gamma, d.has_ctm,
+			       r_s, g_s, b_s);
+	}
+	mutex_unlock(&evdi_color_list_lock);
+	return n;
+}
+
+void evdi_color_transform_apply_row(const struct evdi_color_data *snapshot,
+				    void *row, int width_px, bool swap_rb)
+{
 	u8 *px = row;
 	const int r_idx = swap_rb ? 0 : 2;
 	const int b_idx = swap_rb ? 2 : 0;

--- a/module/evdi_color.c
+++ b/module/evdi_color.c
@@ -13,7 +13,6 @@
 #include <linux/mutex.h>
 #include <linux/slab.h>
 #include <linux/string.h>
-#include <linux/vmalloc.h>
 #include <drm/drm_color_mgmt.h>
 #include <drm/drm_crtc.h>
 #include <drm/drm_fixed.h>
@@ -70,18 +69,29 @@ static bool evdi_ctm_is_diagonal(const s64 m[3][3])
 	return true;
 }
 
-/* Same diagonal matrix, table form — not a different colour model. */
+/*
+ * Same diagonal matrix as a 256-entry LUT — speed only, not a new model.
+ * DRM order is CTM then gamma: when a real LUT is already loaded, compose
+ * gamma_out[i] = gamma_in[clamp(scale * i)] instead of overwriting it.
+ */
 static void evdi_fuse_diagonal_ctm_to_gamma(struct evdi_color_data *data)
 {
+	u8 src_gamma[3][EVDI_GAMMA_LUT_SIZE];
+	const bool compose = data->has_gamma;
 	int c, i;
+
+	if (compose)
+		memcpy(src_gamma, data->gamma, sizeof(src_gamma));
 
 	for (c = 0; c < 3; ++c) {
 		s64 scale = data->ctm[c][c];
 
 		for (i = 0; i < EVDI_GAMMA_LUT_SIZE; ++i) {
 			s64 v = drm_fixp_mul(scale, drm_int2fixp(i));
+			int mid = clamp(drm_fixp2int_round(v), 0, 255);
 
-			data->gamma[c][i] = clamp(drm_fixp2int_round(v), 0, 255);
+			data->gamma[c][i] = compose ? src_gamma[c][mid]
+						    : (u8)mid;
 		}
 	}
 	data->has_gamma = true;
@@ -182,9 +192,6 @@ void evdi_color_transform_cleanup(struct evdi_color_transform *color)
 	mutex_lock(&evdi_color_list_lock);
 	list_del_init(&color->link);
 	mutex_unlock(&evdi_color_list_lock);
-	vfree(color->scratch);
-	color->scratch = NULL;
-	color->scratch_bytes = 0;
 	mutex_destroy(&color->lock);
 }
 
@@ -215,41 +222,6 @@ bool evdi_color_transform_snapshot(struct evdi_color_transform *color,
 	*snapshot = color->data;
 	mutex_unlock(&color->lock);
 	return snapshot->active;
-}
-
-void *evdi_color_get_scratch(struct evdi_color_transform *color, size_t bytes)
-{
-	void *p;
-
-	if (bytes == 0)
-		return NULL;
-
-	mutex_lock(&color->lock);
-	if (color->scratch_bytes >= bytes) {
-		p = color->scratch;
-		mutex_unlock(&color->lock);
-		return p;
-	}
-	vfree(color->scratch);
-	color->scratch = NULL;
-	color->scratch_bytes = 0;
-	mutex_unlock(&color->lock);
-
-	p = vmalloc(bytes);
-	if (!p)
-		return NULL;
-
-	mutex_lock(&color->lock);
-	if (color->scratch_bytes >= bytes) {
-		vfree(p);
-		p = color->scratch;
-	} else {
-		vfree(color->scratch);
-		color->scratch = p;
-		color->scratch_bytes = bytes;
-	}
-	mutex_unlock(&color->lock);
-	return p;
 }
 
 static s64 evdi_color_apply_ctm_channel(const struct evdi_color_data *snapshot,

--- a/module/evdi_color.c
+++ b/module/evdi_color.c
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) 2026 DisplayLink (UK) Ltd.
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file COPYING in the main directory of this archive for
+ * more details.
+ */
+
+#include <linux/kernel.h>
+#include <linux/minmax.h>
+#include <linux/slab.h>
+#include <drm/drm_color_mgmt.h>
+#include <drm/drm_crtc.h>
+#include <drm/drm_fixed.h>
+
+#include "evdi_color.h"
+
+/*
+ * struct drm_color_ctm stores each entry as S31.32 sign-magnitude (bit 63
+ * is the sign, bits 0-62 are the unsigned value) rather than the two's
+ * complement drm_fixed.h (drm_fixp_t) format the drm_fixp_* helpers use.
+ * Some newer kernels provide drm_sm2fixp() for this, but it isn't present
+ * across the full 4.15+ range evdi supports, so convert it ourselves.
+ */
+static s64 evdi_sm2fixp(u64 sm)
+{
+	s64 magnitude = (s64)(sm & ~BIT_ULL(63));
+
+	return (sm & BIT_ULL(63)) ? -magnitude : magnitude;
+}
+
+static void evdi_color_update_gamma(struct evdi_color_data *data,
+				     struct drm_crtc_state *crtc_state)
+{
+	const struct drm_color_lut *lut;
+	unsigned int lut_len;
+	int i, c;
+
+	if (!crtc_state->gamma_lut) {
+		data->has_gamma = false;
+		return;
+	}
+
+	lut = (const struct drm_color_lut *)crtc_state->gamma_lut->data;
+	lut_len = crtc_state->gamma_lut->length / sizeof(*lut);
+
+	if (lut_len == 0) {
+		data->has_gamma = false;
+		return;
+	}
+
+	/*
+	 * Build a direct 256-entry table indexed by raw 8-bit channel value,
+	 * regardless of the length of the LUT userspace actually uploaded
+	 * (expected to be EVDI_GAMMA_LUT_SIZE, since that's what we advertise
+	 * via drm_mode_crtc_set_gamma_size(), but not all clients necessarily
+	 * respect that hint).
+	 */
+	for (i = 0; i < EVDI_GAMMA_LUT_SIZE; ++i) {
+		s64 idx_fp = drm_fixp_div(drm_int2fixp(i * (lut_len - 1)),
+					   drm_int2fixp(EVDI_GAMMA_LUT_SIZE - 1));
+		int idx_floor = drm_fixp2int(idx_fp);
+		int idx_ceil = min_t(int, idx_floor + 1, lut_len - 1);
+		s64 frac = idx_fp - drm_int2fixp(idx_floor);
+		u16 raw[3] = { lut[idx_floor].red, lut[idx_floor].green, lut[idx_floor].blue };
+		u16 raw_ceil[3] = { lut[idx_ceil].red, lut[idx_ceil].green, lut[idx_ceil].blue };
+
+		for (c = 0; c < 3; ++c) {
+			s64 floor_fp = drm_int2fixp(raw[c]);
+			s64 ceil_fp = drm_int2fixp(raw_ceil[c]);
+			s64 interp = floor_fp + drm_fixp_mul(ceil_fp - floor_fp, frac);
+			int val16 = clamp(drm_fixp2int(interp), 0, 65535);
+
+			/* 16-bit LUT entry -> 8-bit raw pixel channel */
+			data->gamma[c][i] = val16 >> 8;
+		}
+	}
+
+	data->has_gamma = true;
+}
+
+static void evdi_color_update_ctm(struct evdi_color_data *data,
+				   struct drm_crtc_state *crtc_state)
+{
+	const struct drm_color_ctm *ctm;
+	int r, c;
+
+	if (!crtc_state->ctm) {
+		data->has_ctm = false;
+		return;
+	}
+
+	ctm = (const struct drm_color_ctm *)crtc_state->ctm->data;
+	for (r = 0; r < 3; ++r)
+		for (c = 0; c < 3; ++c)
+			data->ctm[r][c] = evdi_sm2fixp(ctm->matrix[r * 3 + c]);
+
+	data->has_ctm = true;
+}
+
+void evdi_color_transform_init(struct evdi_color_transform *color)
+{
+	mutex_init(&color->lock);
+	memset(&color->data, 0, sizeof(color->data));
+}
+
+void evdi_color_transform_update(struct evdi_color_transform *color,
+				  struct drm_crtc_state *crtc_state)
+{
+	if (!crtc_state->color_mgmt_changed)
+		return;
+
+	mutex_lock(&color->lock);
+	evdi_color_update_gamma(&color->data, crtc_state);
+	evdi_color_update_ctm(&color->data, crtc_state);
+	color->data.active = color->data.has_gamma || color->data.has_ctm;
+	mutex_unlock(&color->lock);
+}
+
+bool evdi_color_transform_snapshot(struct evdi_color_transform *color,
+				    struct evdi_color_data *snapshot)
+{
+	mutex_lock(&color->lock);
+	*snapshot = color->data;
+	mutex_unlock(&color->lock);
+
+	return snapshot->active;
+}
+
+static s64 evdi_color_apply_ctm_channel(const struct evdi_color_data *snapshot,
+					 int row, s64 r, s64 g, s64 b)
+{
+	return drm_fixp_mul(snapshot->ctm[row][0], r) +
+	       drm_fixp_mul(snapshot->ctm[row][1], g) +
+	       drm_fixp_mul(snapshot->ctm[row][2], b);
+}
+
+void evdi_color_transform_apply_row(const struct evdi_color_data *snapshot,
+				     void *row, int width_px, bool swap_rb)
+{
+	u8 *px = row;
+	const int r_idx = swap_rb ? 2 : 0;
+	const int b_idx = swap_rb ? 0 : 2;
+	int i;
+
+	if (!snapshot->active)
+		return;
+
+	for (i = 0; i < width_px; ++i, px += 4) {
+		int val[3] = { px[r_idx], px[1], px[b_idx] };
+
+		if (snapshot->has_ctm) {
+			s64 r = drm_int2fixp(val[0]);
+			s64 g = drm_int2fixp(val[1]);
+			s64 b = drm_int2fixp(val[2]);
+
+			val[0] = clamp(drm_fixp2int_round(
+				evdi_color_apply_ctm_channel(snapshot, 0, r, g, b)), 0, 255);
+			val[1] = clamp(drm_fixp2int_round(
+				evdi_color_apply_ctm_channel(snapshot, 1, r, g, b)), 0, 255);
+			val[2] = clamp(drm_fixp2int_round(
+				evdi_color_apply_ctm_channel(snapshot, 2, r, g, b)), 0, 255);
+		}
+
+		if (snapshot->has_gamma) {
+			val[0] = snapshot->gamma[0][val[0]];
+			val[1] = snapshot->gamma[1][val[1]];
+			val[2] = snapshot->gamma[2][val[2]];
+		}
+
+		px[r_idx] = val[0];
+		px[1] = val[1];
+		px[b_idx] = val[2];
+	}
+}

--- a/module/evdi_color.c
+++ b/module/evdi_color.c
@@ -105,17 +105,18 @@ void evdi_color_transform_init(struct evdi_color_transform *color)
 	memset(&color->data, 0, sizeof(color->data));
 }
 
-void evdi_color_transform_update(struct evdi_color_transform *color,
-				  struct drm_crtc_state *crtc_state)
+bool evdi_color_transform_update(struct evdi_color_transform *color,
+				 struct drm_crtc_state *crtc_state)
 {
 	if (!crtc_state->color_mgmt_changed)
-		return;
+		return false;
 
 	mutex_lock(&color->lock);
 	evdi_color_update_gamma(&color->data, crtc_state);
 	evdi_color_update_ctm(&color->data, crtc_state);
 	color->data.active = color->data.has_gamma || color->data.has_ctm;
 	mutex_unlock(&color->lock);
+	return true;
 }
 
 bool evdi_color_transform_snapshot(struct evdi_color_transform *color,

--- a/module/evdi_color.h
+++ b/module/evdi_color.h
@@ -9,19 +9,21 @@
 #ifndef EVDI_COLOR_H
 #define EVDI_COLOR_H
 
+#include <linux/list.h>
 #include <linux/mutex.h>
 #include <linux/types.h>
 
 struct drm_crtc_state;
 
 /*
- * evdi has no hardware CRTC gamma/CTM block, so Night Light and other
- * DRM color management clients need the transform applied in software
- * to the raw framebuffer bytes before they leave the driver.
+ * Software colour management: apply whatever the compositor programs on the
+ * CRTC (GAMMA_LUT and/or CTM). No synthesis between the two.
  *
- * Advertised via drm_mode_crtc_set_gamma_size()/drm_crtc_enable_color_mgmt()
- * and consumed here as a direct 8-bit-indexed lookup table, independent of
- * whatever length LUT userspace actually uploads (see evdi_color_transform_update()).
+ * Which properties exist is chosen at module load by color_props=
+ * both|gamma|ctm (see evdi_params). Reload the module to change that.
+ *
+ * Diagonal CTMs are fused into a 256-entry LUT only as a speed optimisation
+ * of the same matrix (Night Light style scales); identity is skipped.
  */
 #define EVDI_GAMMA_LUT_SIZE 256
 
@@ -29,6 +31,7 @@ struct evdi_color_data {
 	bool active;
 	bool has_gamma;
 	bool has_ctm;
+	bool fused_diagonal;
 	u8 gamma[3][EVDI_GAMMA_LUT_SIZE];
 	/* row-major 3x3, drm_fixed.h S32.32 two's-complement fixed point */
 	s64 ctm[3][3];
@@ -36,29 +39,29 @@ struct evdi_color_data {
 
 struct evdi_color_transform {
 	struct mutex lock;
+	struct list_head link;
 	struct evdi_color_data data;
+	struct drm_device *ddev;
+	void *scratch;
+	size_t scratch_bytes;
 };
 
-void evdi_color_transform_init(struct evdi_color_transform *color);
+void evdi_color_transform_init(struct evdi_color_transform *color,
+			       struct drm_device *ddev);
+void evdi_color_transform_cleanup(struct evdi_color_transform *color);
 
-/* Recomputes the LUT/CTM from crtc_state. Returns true when colour
- * properties actually changed (caller should mark the scanout dirty so
- * clients re-grab). No-op when !color_mgmt_changed.
- */
+/* Returns true if the effective apply payload changed (caller may full-dirty). */
 bool evdi_color_transform_update(struct evdi_color_transform *color,
 				 struct drm_crtc_state *crtc_state);
 
-/* Copies the current transform out under lock. Returns whether it's a
- * no-op identity transform, letting the caller skip apply_row() entirely.
- */
 bool evdi_color_transform_snapshot(struct evdi_color_transform *color,
-				    struct evdi_color_data *snapshot);
+				   struct evdi_color_data *snapshot);
 
-/* Applies gamma/CTM in place to one packed 32bpp scanline of width_px
- * pixels. swap_rb selects XBGR/ABGR (R and B swapped vs XRGB/ARGB) byte
- * order; the alpha/padding byte is always left untouched.
- */
+void *evdi_color_get_scratch(struct evdi_color_transform *color, size_t bytes);
+
 void evdi_color_transform_apply_row(const struct evdi_color_data *snapshot,
-				     void *row, int width_px, bool swap_rb);
+				    void *row, int width_px, bool swap_rb);
+
+int evdi_color_format_status(char *buf, size_t size);
 
 #endif

--- a/module/evdi_color.h
+++ b/module/evdi_color.h
@@ -41,11 +41,12 @@ struct evdi_color_transform {
 
 void evdi_color_transform_init(struct evdi_color_transform *color);
 
-/* Recomputes the LUT/CTM from crtc_state; cheap no-op unless
- * crtc_state->color_mgmt_changed is set (i.e. on actual property writes).
+/* Recomputes the LUT/CTM from crtc_state. Returns true when colour
+ * properties actually changed (caller should mark the scanout dirty so
+ * clients re-grab). No-op when !color_mgmt_changed.
  */
-void evdi_color_transform_update(struct evdi_color_transform *color,
-				  struct drm_crtc_state *crtc_state);
+bool evdi_color_transform_update(struct evdi_color_transform *color,
+				 struct drm_crtc_state *crtc_state);
 
 /* Copies the current transform out under lock. Returns whether it's a
  * no-op identity transform, letting the caller skip apply_row() entirely.

--- a/module/evdi_color.h
+++ b/module/evdi_color.h
@@ -23,7 +23,9 @@ struct drm_crtc_state;
  * both|gamma|ctm (see evdi_params). Reload the module to change that.
  *
  * Diagonal CTMs are fused into a 256-entry LUT only as a speed optimisation
- * of the same matrix (Night Light style scales); identity is skipped.
+ * of the same matrix (Night Light style scales). If a gamma LUT is also
+ * present it is composed (CTM then gamma), not overwritten. Identity is
+ * skipped.
  */
 #define EVDI_GAMMA_LUT_SIZE 256
 
@@ -42,8 +44,6 @@ struct evdi_color_transform {
 	struct list_head link;
 	struct evdi_color_data data;
 	struct drm_device *ddev;
-	void *scratch;
-	size_t scratch_bytes;
 };
 
 void evdi_color_transform_init(struct evdi_color_transform *color,
@@ -56,8 +56,6 @@ bool evdi_color_transform_update(struct evdi_color_transform *color,
 
 bool evdi_color_transform_snapshot(struct evdi_color_transform *color,
 				   struct evdi_color_data *snapshot);
-
-void *evdi_color_get_scratch(struct evdi_color_transform *color, size_t bytes);
 
 void evdi_color_transform_apply_row(const struct evdi_color_data *snapshot,
 				    void *row, int width_px, bool swap_rb);

--- a/module/evdi_color.h
+++ b/module/evdi_color.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: GPL-2.0-only
+ * Copyright (c) 2026 DisplayLink (UK) Ltd.
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file COPYING in the main directory of this archive for
+ * more details.
+ */
+
+#ifndef EVDI_COLOR_H
+#define EVDI_COLOR_H
+
+#include <linux/mutex.h>
+#include <linux/types.h>
+
+struct drm_crtc_state;
+
+/*
+ * evdi has no hardware CRTC gamma/CTM block, so Night Light and other
+ * DRM color management clients need the transform applied in software
+ * to the raw framebuffer bytes before they leave the driver.
+ *
+ * Advertised via drm_mode_crtc_set_gamma_size()/drm_crtc_enable_color_mgmt()
+ * and consumed here as a direct 8-bit-indexed lookup table, independent of
+ * whatever length LUT userspace actually uploads (see evdi_color_transform_update()).
+ */
+#define EVDI_GAMMA_LUT_SIZE 256
+
+struct evdi_color_data {
+	bool active;
+	bool has_gamma;
+	bool has_ctm;
+	u8 gamma[3][EVDI_GAMMA_LUT_SIZE];
+	/* row-major 3x3, drm_fixed.h S32.32 two's-complement fixed point */
+	s64 ctm[3][3];
+};
+
+struct evdi_color_transform {
+	struct mutex lock;
+	struct evdi_color_data data;
+};
+
+void evdi_color_transform_init(struct evdi_color_transform *color);
+
+/* Recomputes the LUT/CTM from crtc_state; cheap no-op unless
+ * crtc_state->color_mgmt_changed is set (i.e. on actual property writes).
+ */
+void evdi_color_transform_update(struct evdi_color_transform *color,
+				  struct drm_crtc_state *crtc_state);
+
+/* Copies the current transform out under lock. Returns whether it's a
+ * no-op identity transform, letting the caller skip apply_row() entirely.
+ */
+bool evdi_color_transform_snapshot(struct evdi_color_transform *color,
+				    struct evdi_color_data *snapshot);
+
+/* Applies gamma/CTM in place to one packed 32bpp scanline of width_px
+ * pixels. swap_rb selects XBGR/ABGR (R and B swapped vs XRGB/ARGB) byte
+ * order; the alpha/padding byte is always left untouched.
+ */
+void evdi_color_transform_apply_row(const struct evdi_color_data *snapshot,
+				     void *row, int width_px, bool swap_rb);
+
+#endif

--- a/module/evdi_cursor.c
+++ b/module/evdi_cursor.c
@@ -29,6 +29,7 @@
 #include <drm/drm_crtc_helper.h>
 
 #include "evdi_cursor.h"
+#include "evdi_color.h"
 #include "evdi_drm_drv.h"
 
 /*
@@ -176,17 +177,45 @@ static inline uint32_t blend_alpha(const uint32_t pixel_val32,
 static int evdi_cursor_compose_pixel(char __user *buffer,
 				     int const cursor_value,
 				     int const fb_value,
-				     int cmd_offset)
+				     int cmd_offset,
+				     const struct evdi_color_data *color,
+				     bool swap_rb)
 {
-	int const composed_value = blend_alpha(fb_value, cursor_value);
+	uint32_t composed_value = blend_alpha(fb_value, cursor_value);
+
+	/*
+	 * Primary scanout is already colour-managed in copy_primary_pixels, but
+	 * this path re-blends from the untinted GEM and would undo that under
+	 * the cursor. Apply the same transform to the composed ARGB pixel so
+	 * Night Light matches the desktop (alpha left untouched).
+	 */
+	if (color && color->active) {
+		u8 px[4];
+
+		px[0] = composed_value & 0xff;
+		px[1] = (composed_value >> 8) & 0xff;
+		px[2] = (composed_value >> 16) & 0xff;
+		px[3] = (composed_value >> 24) & 0xff;
+		evdi_color_transform_apply_row(color, px, 1, swap_rb);
+		composed_value = (uint32_t)px[0]
+			| ((uint32_t)px[1] << 8)
+			| ((uint32_t)px[2] << 16)
+			| ((uint32_t)px[3] << 24);
+	}
 
 	return copy_to_user(buffer + cmd_offset, &composed_value, 4);
+}
+
+static bool evdi_cursor_format_swaps_rb(uint32_t format)
+{
+	return format == DRM_FORMAT_XBGR8888 || format == DRM_FORMAT_ABGR8888;
 }
 
 int evdi_cursor_compose_and_copy(struct evdi_cursor *cursor,
 				 struct evdi_framebuffer *efb,
 				 char __user *buffer,
-				 int buf_byte_stride)
+				 int buf_byte_stride,
+				 const struct evdi_color_data *color)
 {
 	int x, y;
 	struct drm_framebuffer *fb = &efb->base;
@@ -194,6 +223,7 @@ int evdi_cursor_compose_and_copy(struct evdi_cursor *cursor,
 	const int h_cursor_h = cursor->height >> 1;
 	uint32_t *cursor_buffer = NULL;
 	uint32_t bytespp = 0;
+	const bool swap_rb = evdi_cursor_format_swaps_rb(cursor->pixel_format);
 
 	if (!cursor->enabled)
 		return 0;
@@ -248,7 +278,9 @@ int evdi_cursor_compose_and_copy(struct evdi_cursor *cursor,
 			if (evdi_cursor_compose_pixel(buffer,
 						      curs_val,
 						      fb_value,
-						      cmd_offset)) {
+						      cmd_offset,
+						      color,
+						      swap_rb)) {
 				EVDI_ERROR("Failed to compose cursor pixel\n");
 				return -EFAULT;
 			}

--- a/module/evdi_cursor.h
+++ b/module/evdi_cursor.h
@@ -31,6 +31,7 @@
 struct evdi_cursor;
 struct evdi_framebuffer;
 struct evdi_gem_object;
+struct evdi_color_data;
 
 int evdi_cursor_init(struct evdi_cursor **cursor);
 void evdi_cursor_free(struct evdi_cursor *cursor);
@@ -57,5 +58,6 @@ struct evdi_gem_object *evdi_cursor_gem(struct evdi_cursor *cursor);
 int evdi_cursor_compose_and_copy(struct evdi_cursor *cursor,
 				 struct evdi_framebuffer *efb,
 				 char __user *buffer,
-				 int buf_byte_stride);
+				 int buf_byte_stride,
+				 const struct evdi_color_data *color);
 #endif

--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -188,6 +188,7 @@ static int evdi_drm_device_init(struct drm_device *dev)
 	ret =  evdi_cursor_init(&evdi->cursor);
 	if (ret)
 		goto err_free;
+	evdi_color_transform_init(&evdi->color);
 
 	evdi_modeset_init(dev);
 

--- a/module/evdi_drm_drv.c
+++ b/module/evdi_drm_drv.c
@@ -159,6 +159,7 @@ static void evdi_drm_device_release_cb(__always_unused struct drm_device *dev,
 {
 	struct evdi_device *evdi = dev->dev_private;
 
+	evdi_color_transform_cleanup(&evdi->color);
 	evdi_cursor_free(evdi->cursor);
 	evdi_painter_cleanup(evdi->painter);
 	kfree(evdi);
@@ -188,7 +189,7 @@ static int evdi_drm_device_init(struct drm_device *dev)
 	ret =  evdi_cursor_init(&evdi->cursor);
 	if (ret)
 		goto err_free;
-	evdi_color_transform_init(&evdi->color);
+	evdi_color_transform_init(&evdi->color, dev);
 
 	evdi_modeset_init(dev);
 
@@ -206,6 +207,7 @@ static int evdi_drm_device_init(struct drm_device *dev)
 	return 0;
 
 err_init:
+	evdi_color_transform_cleanup(&evdi->color);
 err_free:
 	EVDI_ERROR("Failed to setup drm device %d\n", ret);
 	evdi_cursor_free(evdi->cursor);

--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -38,6 +38,7 @@
 #include <drm/drm_framebuffer.h>
 #include <drm/drm_fb_helper.h>
 
+#include "evdi_color.h"
 #include "evdi_debug.h"
 #include "tests/evdi_test.h"
 
@@ -49,6 +50,7 @@ struct evdi_device {
 	struct drm_connector *conn;
 	struct evdi_cursor *cursor;
 	bool cursor_events_enabled;
+	struct evdi_color_transform color;
 
 	uint32_t pixel_area_limit;
 	uint32_t pixel_per_second_limit;

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -90,9 +90,10 @@ static void evdi_crtc_atomic_flush(
 	bool notify_dpms = crtc_state->active_changed || evdi_painter_needs_full_modeset(evdi->painter);
 
 	/*
-	 * Colour is applied only on GRABPIX of dirty rects. When the compositor
-	 * changes GAMMA_LUT/CTM without repainting, force a full-frame dirty so
-	 * DisplayLinkManager re-grabs and the new transform is visible.
+	 * Refresh the software transform from compositor blobs. If the
+	 * effective apply payload changed, full-dirty so a static desktop
+	 * re-grabs (Night Light toggle / temperature). Identity is skipped
+	 * in evdi_color so redundant updates do not spam USB.
 	 */
 	if (evdi_color_transform_update(&evdi->color, crtc_state)) {
 		struct drm_clip_rect full =

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -89,7 +89,18 @@ static void evdi_crtc_atomic_flush(
 				   (crtc_state->mode_changed || evdi_painter_needs_full_modeset(evdi->painter));
 	bool notify_dpms = crtc_state->active_changed || evdi_painter_needs_full_modeset(evdi->painter);
 
-	evdi_color_transform_update(&evdi->color, crtc_state);
+	/*
+	 * Colour is applied only on GRABPIX of dirty rects. When the compositor
+	 * changes GAMMA_LUT/CTM without repainting, force a full-frame dirty so
+	 * DisplayLinkManager re-grabs and the new transform is visible.
+	 */
+	if (evdi_color_transform_update(&evdi->color, crtc_state)) {
+		struct drm_clip_rect full =
+			evdi_painter_framebuffer_size(evdi->painter);
+
+		if (full.x2 > full.x1 && full.y2 > full.y1)
+			evdi_painter_mark_dirty(evdi, &full);
+	}
 
 	if (notify_mode_changed)
 		evdi_painter_mode_changed_notify(evdi, &crtc_state->adjusted_mode);

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -101,6 +101,12 @@ static void evdi_crtc_atomic_flush(
 
 		if (full.x2 > full.x1 && full.y2 > full.y1)
 			evdi_painter_mark_dirty(evdi, &full);
+		/*
+		 * Cursor events path must re-hide/restore the HW cursor when
+		 * software colour turns on/off so tint stays on the SW blend.
+		 */
+		if (evdi->cursor_events_enabled)
+			evdi_painter_send_cursor_set(evdi->painter, evdi->cursor);
 	}
 
 	if (notify_mode_changed)
@@ -173,12 +179,19 @@ static int evdi_crtc_cursor_set(struct drm_crtc *crtc,
 
 	/*
 	 * For now we don't care whether the application wanted the mouse set,
-	 * or not.
+	 * or not. Colour-active forces SW blend (tinted); keep DLM's HW cursor
+	 * hidden via the set event when events are enabled.
 	 */
-	if (evdi->cursor_events_enabled)
-		evdi_painter_send_cursor_set(evdi->painter, evdi->cursor);
-	else
-		evdi_mark_full_screen_dirty(evdi);
+	{
+		struct evdi_color_data color_snap;
+		const bool color_active =
+			evdi_color_transform_snapshot(&evdi->color, &color_snap);
+
+		if (evdi->cursor_events_enabled)
+			evdi_painter_send_cursor_set(evdi->painter, evdi->cursor);
+		if (!evdi->cursor_events_enabled || color_active)
+			evdi_mark_full_screen_dirty(evdi);
+	}
 	return 0;
 }
 
@@ -186,11 +199,14 @@ static int evdi_crtc_cursor_move(struct drm_crtc *crtc, int x, int y)
 {
 	struct drm_device *dev = crtc->dev;
 	struct evdi_device *evdi = dev->dev_private;
+	struct evdi_color_data color_snap;
+	const bool color_active =
+		evdi_color_transform_snapshot(&evdi->color, &color_snap);
 
 	EVDI_CHECKPT();
 	evdi_cursor_move(evdi->cursor, x, y);
 
-	if (evdi->cursor_events_enabled)
+	if (evdi->cursor_events_enabled && !color_active)
 		evdi_painter_send_cursor_move(evdi->painter, evdi->cursor);
 	else
 		evdi_mark_full_screen_dirty(evdi);
@@ -390,19 +406,35 @@ static void evdi_cursor_atomic_update(struct drm_plane *plane,
 			cursor_changed = true;
 		}
 
-		if (!evdi->cursor_events_enabled) {
-			if (fb != NULL) {
-				if (efb->obj->allow_sw_cursor_rect_updates) {
-					evdi_cursor_atomic_get_rect(&old_rect, old_state);
-					evdi_cursor_atomic_get_rect(&rect, state);
+		{
+			struct evdi_color_data color_snap;
+			const bool color_active =
+				evdi_color_transform_snapshot(&evdi->color,
+							      &color_snap);
+			/* SW blend when events off, or when colour forces tint. */
+			const bool sw_cursor =
+				!evdi->cursor_events_enabled || color_active;
 
-					evdi_painter_mark_dirty(evdi, &old_rect);
-				} else {
-					rect = evdi_painter_framebuffer_size(evdi->painter);
+			if (sw_cursor) {
+				if (fb != NULL) {
+					if (efb->obj->allow_sw_cursor_rect_updates) {
+						evdi_cursor_atomic_get_rect(&old_rect,
+									    old_state);
+						evdi_cursor_atomic_get_rect(&rect, state);
+
+						evdi_painter_mark_dirty(evdi, &old_rect);
+					} else {
+						rect = evdi_painter_framebuffer_size(
+							evdi->painter);
+					}
+					evdi_painter_mark_dirty(evdi, &rect);
 				}
-				evdi_painter_mark_dirty(evdi, &rect);
+				/* Keep DLM HW cursor hidden while colour is active. */
+				if (evdi->cursor_events_enabled && cursor_changed)
+					evdi_painter_send_cursor_set(evdi->painter,
+								     evdi->cursor);
+				return;
 			}
-			return;
 		}
 
 		if (cursor_changed)

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -519,14 +519,23 @@ static int evdi_crtc_init(struct drm_device *dev)
 	drm_crtc_helper_add(crtc, &evdi_helper_funcs);
 
 	/*
-	 * evdi has no hardware gamma/CTM block to program; the properties
-	 * registered here are applied in software to the raw framebuffer
-	 * bytes in evdi_painter.c's copy_primary_pixels()/_on_xe(), since
-	 * that's the only place the driver has direct access to pixel data
-	 * before it's handed to userspace.
+	 * Software colour management (see evdi_color.c). Which properties are
+	 * advertised is selected by the color_props module parameter so a
+	 * compositor can be steered to GAMMA_LUT or CTM for testing.
 	 */
-	drm_mode_crtc_set_gamma_size(crtc, EVDI_GAMMA_LUT_SIZE);
-	drm_crtc_enable_color_mgmt(crtc, 0, true, EVDI_GAMMA_LUT_SIZE);
+	{
+		const bool has_gamma = evdi_color_props_has_gamma();
+		const bool has_ctm = evdi_color_props_has_ctm();
+		const uint gamma_size = has_gamma ? EVDI_GAMMA_LUT_SIZE : 0;
+
+		if (has_gamma)
+			drm_mode_crtc_set_gamma_size(crtc, EVDI_GAMMA_LUT_SIZE);
+		if (has_gamma || has_ctm)
+			drm_crtc_enable_color_mgmt(crtc, 0, has_ctm, gamma_size);
+		EVDI_INFO("color_props=%s (gamma=%d ctm=%d)\n",
+			  evdi_color_props ? evdi_color_props : "both",
+			  has_gamma, has_ctm);
+	}
 
 	return 0;
 }

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -23,12 +23,14 @@
 #include <drm/drmP.h>
 #endif
 #include <drm/drm_atomic.h>
+#include <drm/drm_color_mgmt.h>
 #include <drm/drm_crtc.h>
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_plane_helper.h>
 #include <drm/drm_atomic_helper.h>
 #include "evdi_drm.h"
 #include "evdi_drm_drv.h"
+#include "evdi_color.h"
 #include "evdi_cursor.h"
 #include "evdi_params.h"
 #ifdef EVDI_HAVE_DRM_GEM_PLANE_HELPER_PREPARE_FB
@@ -86,6 +88,8 @@ static void evdi_crtc_atomic_flush(
 	bool notify_mode_changed = crtc_state->active &&
 				   (crtc_state->mode_changed || evdi_painter_needs_full_modeset(evdi->painter));
 	bool notify_dpms = crtc_state->active_changed || evdi_painter_needs_full_modeset(evdi->painter);
+
+	evdi_color_transform_update(&evdi->color, crtc_state);
 
 	if (notify_mode_changed)
 		evdi_painter_mode_changed_notify(evdi, &crtc_state->adjusted_mode);
@@ -502,6 +506,16 @@ static int evdi_crtc_init(struct drm_device *dev)
 
 	EVDI_DEBUG("drm_crtc_init: %d p%p\n", status, primary_plane);
 	drm_crtc_helper_add(crtc, &evdi_helper_funcs);
+
+	/*
+	 * evdi has no hardware gamma/CTM block to program; the properties
+	 * registered here are applied in software to the raw framebuffer
+	 * bytes in evdi_painter.c's copy_primary_pixels()/_on_xe(), since
+	 * that's the only place the driver has direct access to pixel data
+	 * before it's handed to userspace.
+	 */
+	drm_mode_crtc_set_gamma_size(crtc, EVDI_GAMMA_LUT_SIZE);
+	drm_crtc_enable_color_mgmt(crtc, 0, true, EVDI_GAMMA_LUT_SIZE);
 
 	return 0;
 }

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -299,13 +299,15 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 static void copy_cursor_pixels(struct evdi_framebuffer *efb,
 			       char __user *buffer,
 			       int buf_byte_stride,
-			       struct evdi_cursor *cursor)
+			       struct evdi_cursor *cursor,
+			       const struct evdi_color_data *color)
 {
 	evdi_cursor_lock(cursor);
 	if (evdi_cursor_compose_and_copy(cursor,
 					 efb,
 					 buffer,
-					 buf_byte_stride))
+					 buf_byte_stride,
+					 color))
 		EVDI_ERROR("Failed to blend cursor\n");
 
 	evdi_cursor_unlock(cursor);
@@ -1215,7 +1217,8 @@ int evdi_painter_grabpix_ioctl(struct drm_device *drm_dev, void *data,
 		copy_cursor_pixels(efb,
 				   cmd->buffer,
 				   cmd->buf_byte_stride,
-				   evdi->cursor);
+				   evdi->cursor,
+				   &color);
 
 	if (import_attach)
 		dma_buf_end_cpu_access(import_attach->dmabuf,

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -231,13 +231,14 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 			       int num_rects, struct drm_clip_rect *rects,
 			       int const max_x,
 			       int const max_y,
-			       const struct evdi_color_data *color,
-			       struct evdi_color_transform *color_tf)
+			       const struct evdi_color_data *color)
 {
 	struct drm_framebuffer *fb = &efb->base;
 	struct drm_clip_rect *r;
 	const bool swap_rb = evdi_format_swaps_rb(fb->format->format);
+	/* Per-grab row — never share freable storage across concurrent GRABPIX. */
 	char *scratch_row = NULL;
+	int ret = 0;
 
 	EVDI_CHECKPT();
 
@@ -247,7 +248,9 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 #endif
 
 	if (color->active) {
-		scratch_row = evdi_color_get_scratch(color_tf, (size_t)max_x * 4);
+		if (max_x <= 0)
+			return 0;
+		scratch_row = kvmalloc((size_t)max_x * 4, GFP_KERNEL);
 		if (!scratch_row)
 			return -ENOMEM;
 	}
@@ -265,7 +268,8 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 		/* rect size may correspond to previous resolution */
 		if (max_x < r->x2 || max_y < r->y2) {
 			EVDI_WARN("Rect size beyond expected dimensions\n");
-			return -EFAULT;
+			ret = -EFAULT;
+			goto out;
 		}
 
 		EVDI_VERBOSE("copy rect %d,%d-%d,%d\n", r->x1, r->y1, r->x2,
@@ -279,10 +283,13 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 				memcpy(scratch_row, src, byte_span);
 				evdi_color_transform_apply_row(color, scratch_row,
 								byte_span / 4, swap_rb);
-				if (copy_to_user(dst, scratch_row, byte_span))
-					return -EFAULT;
+				if (copy_to_user(dst, scratch_row, byte_span)) {
+					ret = -EFAULT;
+					goto out;
+				}
 			} else if (copy_to_user(dst, src, byte_span)) {
-				return -EFAULT;
+				ret = -EFAULT;
+				goto out;
 			}
 
 			src += fb->pitches[0];
@@ -290,7 +297,9 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 		}
 	}
 
-	return 0;
+out:
+	kvfree(scratch_row);
+	return ret;
 }
 
 static void copy_cursor_pixels(struct evdi_framebuffer *efb,
@@ -498,6 +507,10 @@ static struct drm_pending_event *create_cursor_set_event(
 {
 	struct evdi_event_cursor_set_pending *event;
 	struct evdi_gem_object *eobj = NULL;
+	struct evdi_device *evdi = painter->drm_device ?
+		painter->drm_device->dev_private : NULL;
+	struct evdi_color_data color_snap;
+	bool color_active = false;
 
 	event = kzalloc_obj(*event, GFP_KERNEL);
 	if (!event) {
@@ -507,6 +520,10 @@ static struct drm_pending_event *create_cursor_set_event(
 
 	event->cursor_set.base.type = DRM_EVDI_EVENT_CURSOR_SET;
 	event->cursor_set.base.length = sizeof(event->cursor_set);
+
+	if (evdi)
+		color_active = evdi_color_transform_snapshot(&evdi->color,
+							     &color_snap);
 
 	evdi_cursor_lock(cursor);
 	event->cursor_set.enabled = evdi_cursor_enabled(cursor);
@@ -524,6 +541,16 @@ static struct drm_pending_event *create_cursor_set_event(
 		event->cursor_set.buffer_length = eobj->base.size;
 	if (!event->cursor_set.buffer_handle) {
 		event->cursor_set.enabled = false;
+		event->cursor_set.buffer_length = 0;
+	}
+	/*
+	 * Hardware cursor events expose the untinted GEM. While software
+	 * colour is active, hide the HW cursor so GRABPIX SW-blends a tinted
+	 * one instead (see grabpix_ioctl).
+	 */
+	if (color_active) {
+		event->cursor_set.enabled = false;
+		event->cursor_set.buffer_handle = 0;
 		event->cursor_set.buffer_length = 0;
 	}
 	evdi_cursor_unlock(cursor);
@@ -1209,9 +1236,13 @@ int evdi_painter_grabpix_ioctl(struct drm_device *drm_dev, void *data,
 				  dirty_rects,
 				  cmd->buf_width,
 				  cmd->buf_height,
-				  &color,
-				  &evdi->color);
-	if (err == 0 && !evdi->cursor_events_enabled)
+				  &color);
+	/*
+	 * Cursor events hand DLM an untinted GEM. When colour is active, force
+	 * the software blend path (which applies the same transform) instead.
+	 * create_cursor_set_event hides the HW cursor so DLM does not double-draw.
+	 */
+	if (err == 0 && (!evdi->cursor_events_enabled || color.active))
 		copy_cursor_pixels(efb,
 				   cmd->buffer,
 				   cmd->buf_byte_stride,
@@ -1565,6 +1596,9 @@ int evdi_painter_enable_cursor_events_ioctl(struct drm_device *drm_dev, void *da
 	struct drm_evdi_enable_cursor_events *cmd = data;
 
 	evdi->cursor_events_enabled = cmd->enable;
+	/* Re-advertise cursor so colour-active force-hide / restore applies. */
+	if (evdi->painter && evdi->cursor)
+		evdi_painter_send_cursor_set(evdi->painter, evdi->cursor);
 
 	return 0;
 }

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -231,7 +231,8 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 			       int num_rects, struct drm_clip_rect *rects,
 			       int const max_x,
 			       int const max_y,
-			       const struct evdi_color_data *color)
+			       const struct evdi_color_data *color,
+			       struct evdi_color_transform *color_tf)
 {
 	struct drm_framebuffer *fb = &efb->base;
 	struct drm_clip_rect *r;
@@ -246,7 +247,7 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 #endif
 
 	if (color->active) {
-		scratch_row = vmalloc(max_x * 4);
+		scratch_row = evdi_color_get_scratch(color_tf, (size_t)max_x * 4);
 		if (!scratch_row)
 			return -ENOMEM;
 	}
@@ -264,7 +265,6 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 		/* rect size may correspond to previous resolution */
 		if (max_x < r->x2 || max_y < r->y2) {
 			EVDI_WARN("Rect size beyond expected dimensions\n");
-			vfree(scratch_row);
 			return -EFAULT;
 		}
 
@@ -279,10 +279,8 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 				memcpy(scratch_row, src, byte_span);
 				evdi_color_transform_apply_row(color, scratch_row,
 								byte_span / 4, swap_rb);
-				if (copy_to_user(dst, scratch_row, byte_span)) {
-					vfree(scratch_row);
+				if (copy_to_user(dst, scratch_row, byte_span))
 					return -EFAULT;
-				}
 			} else if (copy_to_user(dst, src, byte_span)) {
 				return -EFAULT;
 			}
@@ -292,7 +290,6 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 		}
 	}
 
-	vfree(scratch_row);
 	return 0;
 }
 
@@ -1212,7 +1209,8 @@ int evdi_painter_grabpix_ioctl(struct drm_device *drm_dev, void *data,
 				  dirty_rects,
 				  cmd->buf_width,
 				  cmd->buf_height,
-				  &color);
+				  &color,
+				  &evdi->color);
 	if (err == 0 && !evdi->cursor_events_enabled)
 		copy_cursor_pixels(efb,
 				   cmd->buffer,

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -23,6 +23,7 @@
 #include <drm/drm_cache.h>
 #include "evdi_drm.h"
 #include "evdi_drm_drv.h"
+#include "evdi_color.h"
 #include "evdi_cursor.h"
 #include "evdi_params.h"
 #include "evdi_i2c.h"
@@ -177,16 +178,23 @@ static void collapse_dirty_rects(struct drm_clip_rect *rects, int *count)
 	*count = 1;
 }
 
+static bool evdi_format_swaps_rb(uint32_t format)
+{
+	return format == DRM_FORMAT_XBGR8888 || format == DRM_FORMAT_ABGR8888;
+}
+
 #if defined(EVDI_HAVE_IOSYS_MAP) && defined(CONFIG_X86)
 static int copy_primary_pixels_on_xe(struct evdi_framebuffer *efb,
 			       char __user *buffer,
 			       int buf_byte_stride,
 			       int const max_x,
-			       int const max_y)
+			       int const max_y,
+			       const struct evdi_color_data *color)
 {
 	int y;
 	struct drm_framebuffer *fb = &efb->base;
 	const int byte_span = max_x * 4;
+	const bool swap_rb = evdi_format_swaps_rb(fb->format->format);
 	struct iosys_map dst_mapping = IOSYS_MAP_INIT_VADDR(vmalloc(max_x * 4));
 
 	if (!dst_mapping.vaddr)
@@ -200,6 +208,8 @@ static int copy_primary_pixels_on_xe(struct evdi_framebuffer *efb,
 
 		drm_clflush_virt_range(src_mapping.vaddr, byte_span);
 		drm_memcpy_from_wc(&dst_mapping, &src_mapping, byte_span);
+		if (color->active)
+			evdi_color_transform_apply_row(color, dst_mapping.vaddr, max_x, swap_rb);
 		if (copy_to_user(dst, dst_mapping.vaddr, byte_span)) {
 			vfree(dst_mapping.vaddr);
 			return -EFAULT;
@@ -220,17 +230,26 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 			       int buf_byte_stride,
 			       int num_rects, struct drm_clip_rect *rects,
 			       int const max_x,
-			       int const max_y)
+			       int const max_y,
+			       const struct evdi_color_data *color)
 {
 	struct drm_framebuffer *fb = &efb->base;
 	struct drm_clip_rect *r;
+	const bool swap_rb = evdi_format_swaps_rb(fb->format->format);
+	char *scratch_row = NULL;
 
 	EVDI_CHECKPT();
 
 #if defined(EVDI_HAVE_IOSYS_MAP) && defined(CONFIG_X86)
 	if (efb->is_from_xe)
-		return copy_primary_pixels_on_xe(efb, buffer, buf_byte_stride, max_x, max_y);
+		return copy_primary_pixels_on_xe(efb, buffer, buf_byte_stride, max_x, max_y, color);
 #endif
+
+	if (color->active) {
+		scratch_row = vmalloc(max_x * 4);
+		if (!scratch_row)
+			return -ENOMEM;
+	}
 
 	for (r = rects; r != rects + num_rects; ++r) {
 		const int byte_offset = r->x1 * 4;
@@ -245,6 +264,7 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 		/* rect size may correspond to previous resolution */
 		if (max_x < r->x2 || max_y < r->y2) {
 			EVDI_WARN("Rect size beyond expected dimensions\n");
+			vfree(scratch_row);
 			return -EFAULT;
 		}
 
@@ -255,14 +275,24 @@ static int copy_primary_pixels(struct evdi_framebuffer *efb,
 #if defined(CONFIG_X86)
 			drm_clflush_virt_range((void *)src, byte_span);
 #endif
-			if (copy_to_user(dst, src, byte_span))
+			if (color->active) {
+				memcpy(scratch_row, src, byte_span);
+				evdi_color_transform_apply_row(color, scratch_row,
+								byte_span / 4, swap_rb);
+				if (copy_to_user(dst, scratch_row, byte_span)) {
+					vfree(scratch_row);
+					return -EFAULT;
+				}
+			} else if (copy_to_user(dst, src, byte_span)) {
 				return -EFAULT;
+			}
 
 			src += fb->pitches[0];
 			dst += buf_byte_stride;
 		}
 	}
 
+	vfree(scratch_row);
 	return 0;
 }
 
@@ -1074,6 +1104,9 @@ int evdi_painter_grabpix_ioctl(struct drm_device *drm_dev, void *data,
 	int err;
 	int ret;
 	struct dma_buf_attachment *import_attach;
+	struct evdi_color_data color;
+
+	evdi_color_transform_snapshot(&evdi->color, &color);
 
 	EVDI_CHECKPT();
 
@@ -1176,7 +1209,8 @@ int evdi_painter_grabpix_ioctl(struct drm_device *drm_dev, void *data,
 				  cmd->num_rects,
 				  dirty_rects,
 				  cmd->buf_width,
-				  cmd->buf_height);
+				  cmd->buf_height,
+				  &color);
 	if (err == 0 && !evdi->cursor_events_enabled)
 		copy_cursor_pixels(efb,
 				   cmd->buffer,

--- a/module/evdi_params.c
+++ b/module/evdi_params.c
@@ -7,12 +7,14 @@
  * more details.
  */
 
+#include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 #include <linux/string.h>
 
 #include "evdi_params.h"
 #include "evdi_debug.h"
+#include "evdi_color.h"
 
 unsigned int evdi_loglevel __read_mostly = EVDI_LOGLEVEL_INFO;
 unsigned short int evdi_initial_device_count __read_mostly;
@@ -25,9 +27,23 @@ module_param_named(initial_device_count,
 		   evdi_initial_device_count, ushort, 0644);
 MODULE_PARM_DESC(initial_device_count, "Initial DRM device count (default: 0)");
 
-module_param_named(color_props, evdi_color_props, charp, 0644);
+module_param_named(color_props, evdi_color_props, charp, 0444);
 MODULE_PARM_DESC(color_props,
-		 "Colour properties to advertise: both, gamma, or ctm (default: both)");
+		 "Load-time DRM colour props: both, gamma, or ctm (default both). "
+		 "Requires module reload. Mutter uses GAMMA_LUT if present, else CTM.");
+
+static int color_status_get(char *buffer, const struct kernel_param *kp)
+{
+	return evdi_color_format_status(buffer, PAGE_SIZE);
+}
+
+static const struct kernel_param_ops color_status_ops = {
+	.get = color_status_get,
+};
+
+module_param_cb(color_status, &color_status_ops, NULL, 0444);
+MODULE_PARM_DESC(color_status,
+		 "Read-only: advertised mode and per-card effective transform");
 
 bool evdi_color_props_has_gamma(void)
 {
@@ -35,7 +51,6 @@ bool evdi_color_props_has_gamma(void)
 		return true;
 	if (!strcmp(evdi_color_props, "ctm"))
 		return false;
-	/* both, gamma, or unknown → offer gamma */
 	return true;
 }
 
@@ -45,7 +60,5 @@ bool evdi_color_props_has_ctm(void)
 		return true;
 	if (!strcmp(evdi_color_props, "gamma"))
 		return false;
-	/* both, ctm, or unknown → offer CTM */
 	return true;
 }
-

--- a/module/evdi_params.c
+++ b/module/evdi_params.c
@@ -9,12 +9,14 @@
 
 #include <linux/module.h>
 #include <linux/moduleparam.h>
+#include <linux/string.h>
 
 #include "evdi_params.h"
 #include "evdi_debug.h"
 
 unsigned int evdi_loglevel __read_mostly = EVDI_LOGLEVEL_INFO;
 unsigned short int evdi_initial_device_count __read_mostly;
+char *evdi_color_props __read_mostly = "both";
 
 module_param_named(initial_loglevel, evdi_loglevel, int, 0400);
 MODULE_PARM_DESC(initial_loglevel, "Initial log level");
@@ -22,4 +24,28 @@ MODULE_PARM_DESC(initial_loglevel, "Initial log level");
 module_param_named(initial_device_count,
 		   evdi_initial_device_count, ushort, 0644);
 MODULE_PARM_DESC(initial_device_count, "Initial DRM device count (default: 0)");
+
+module_param_named(color_props, evdi_color_props, charp, 0644);
+MODULE_PARM_DESC(color_props,
+		 "Colour properties to advertise: both, gamma, or ctm (default: both)");
+
+bool evdi_color_props_has_gamma(void)
+{
+	if (!evdi_color_props)
+		return true;
+	if (!strcmp(evdi_color_props, "ctm"))
+		return false;
+	/* both, gamma, or unknown → offer gamma */
+	return true;
+}
+
+bool evdi_color_props_has_ctm(void)
+{
+	if (!evdi_color_props)
+		return true;
+	if (!strcmp(evdi_color_props, "gamma"))
+		return false;
+	/* both, ctm, or unknown → offer CTM */
+	return true;
+}
 

--- a/module/evdi_params.h
+++ b/module/evdi_params.h
@@ -13,14 +13,17 @@ extern unsigned int evdi_loglevel;
 extern unsigned short int evdi_initial_device_count;
 
 /*
- * Which DRM colour properties to advertise (compositors pick Night Light path
- * from what is present). Set at module load, e.g.:
- *   modprobe evdi color_props=ctm
- *   EVDI_COLOR_PROPS=gamma sudo ./scripts/install.sh
+ * color_props — load-time only (read at CRTC init). Reload the module to change.
  *
- *   both  — GAMMA_LUT + CTM (default; GNOME prefers GAMMA_LUT)
- *   gamma — GAMMA_LUT only
- *   ctm   — CTM only (useful to force Mutter CTM path)
+ *   both  (default) — advertise GAMMA_LUT + CTM
+ *   gamma           — GAMMA_LUT only
+ *   ctm             — CTM only
+ *
+ *   modprobe evdi color_props=ctm
+ *   EVDI_COLOR_PROPS=ctm sudo ./scripts/install.sh
+ *
+ * Mutter Night Light: uses GAMMA_LUT if present, else CTM. So color_props=ctm
+ * makes GNOME send a real CTM (with a Mutter that supports CTM Night Light).
  */
 extern char *evdi_color_props;
 

--- a/module/evdi_params.h
+++ b/module/evdi_params.h
@@ -12,4 +12,19 @@
 extern unsigned int evdi_loglevel;
 extern unsigned short int evdi_initial_device_count;
 
+/*
+ * Which DRM colour properties to advertise (compositors pick Night Light path
+ * from what is present). Set at module load, e.g.:
+ *   modprobe evdi color_props=ctm
+ *   EVDI_COLOR_PROPS=gamma sudo ./scripts/install.sh
+ *
+ *   both  — GAMMA_LUT + CTM (default; GNOME prefers GAMMA_LUT)
+ *   gamma — GAMMA_LUT only
+ *   ctm   — CTM only (useful to force Mutter CTM path)
+ */
+extern char *evdi_color_props;
+
+bool evdi_color_props_has_gamma(void);
+bool evdi_color_props_has_ctm(void);
+
 #endif /* EVDI_PARAMS_H */

--- a/module/tests/Makefile
+++ b/module/tests/Makefile
@@ -1,5 +1,5 @@
 
 ccflags-$(CONFIG_DRM_EVDI_KUNIT_TEST) += -I$(srctree)/drivers/gpu/drm/evdi
 
-obj-$(CONFIG_DRM_EVDI_KUNIT_TEST) += evdi_test.o test_evdi_vt_switch.o evdi_fake_user_client.o evdi_fake_compositor.o
+obj-$(CONFIG_DRM_EVDI_KUNIT_TEST) += evdi_test.o test_evdi_vt_switch.o test_evdi_color.o evdi_fake_user_client.o evdi_fake_compositor.o
 

--- a/module/tests/test_evdi_color.c
+++ b/module/tests/test_evdi_color.c
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) 2026 DisplayLink (UK) Ltd.
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file COPYING in the main directory of this archive for
+ * more details.
+ */
+
+#include <kunit/test.h>
+#include <drm/drm_fixed.h>
+#include <drm/drm_mode.h>
+
+#include "evdi_color.h"
+
+static void test_identity_is_noop(struct kunit *test)
+{
+	struct evdi_color_data data = { 0 };
+	u8 row[8] = { 10, 20, 30, 40, 200, 100, 50, 255 };
+	u8 expected[8];
+
+	memcpy(expected, row, sizeof(row));
+
+	evdi_color_transform_apply_row(&data, row, 2, false);
+
+	KUNIT_EXPECT_MEMEQ(test, row, expected, sizeof(row));
+}
+
+static void test_gamma_lut_applied_per_channel(struct kunit *test)
+{
+	struct evdi_color_data data = { 0 };
+	u8 row[4] = { 10, 20, 30, 0xAA }; /* B, G, R, X (XRGB8888 byte order) */
+	int i;
+
+	data.active = true;
+	data.has_gamma = true;
+	for (i = 0; i < EVDI_GAMMA_LUT_SIZE; ++i) {
+		data.gamma[0][i] = 255 - i; /* invert blue */
+		data.gamma[1][i] = i;       /* identity green */
+		data.gamma[2][i] = 0;       /* zero red */
+	}
+
+	evdi_color_transform_apply_row(&data, row, 1, false);
+
+	KUNIT_EXPECT_EQ(test, row[0], (u8)(255 - 10));
+	KUNIT_EXPECT_EQ(test, row[1], (u8)20);
+	KUNIT_EXPECT_EQ(test, row[2], (u8)0);
+	KUNIT_EXPECT_EQ(test, row[3], (u8)0xAA); /* X/alpha byte untouched */
+}
+
+static void test_ctm_swaps_channels(struct kunit *test)
+{
+	struct evdi_color_data data = { 0 };
+	/* out = [ [0 0 1] [0 1 0] [1 0 0] ] x in : swaps R and B, keeps G */
+	u8 row[4] = { 10, 20, 30, 0 }; /* B=10 G=20 R=30 (XRGB8888) */
+
+	data.active = true;
+	data.has_ctm = true;
+	data.ctm[0][2] = drm_int2fixp(1); /* out_r = in_b */
+	data.ctm[1][1] = drm_int2fixp(1); /* out_g = in_g */
+	data.ctm[2][0] = drm_int2fixp(1); /* out_b = in_r */
+
+	evdi_color_transform_apply_row(&data, row, 1, false);
+
+	/* row[0]=B should become old R (30), row[2]=R should become old B (10) */
+	KUNIT_EXPECT_EQ(test, row[0], (u8)30);
+	KUNIT_EXPECT_EQ(test, row[1], (u8)20);
+	KUNIT_EXPECT_EQ(test, row[2], (u8)10);
+}
+
+static void test_swap_rb_targets_correct_bytes(struct kunit *test)
+{
+	struct evdi_color_data data = { 0 };
+	u8 row_xrgb[4] = { 1, 2, 3, 9 };  /* B, G, R, X */
+	u8 row_xbgr[4] = { 3, 2, 1, 9 };  /* R, G, B, X - same logical pixel */
+	int i;
+
+	data.active = true;
+	data.has_gamma = true;
+	for (i = 0; i < EVDI_GAMMA_LUT_SIZE; ++i) {
+		data.gamma[0][i] = i * 2 > 255 ? 255 : i * 2; /* boost red */
+		data.gamma[1][i] = i;
+		data.gamma[2][i] = i;
+	}
+
+	evdi_color_transform_apply_row(&data, row_xrgb, 1, false);
+	evdi_color_transform_apply_row(&data, row_xbgr, 1, true);
+
+	/* Both encode the same logical (R,G,B); result must match once
+	 * accounting for the swapped byte layout.
+	 */
+	KUNIT_EXPECT_EQ(test, row_xrgb[2], row_xbgr[0]); /* R byte */
+	KUNIT_EXPECT_EQ(test, row_xrgb[1], row_xbgr[1]); /* G byte */
+	KUNIT_EXPECT_EQ(test, row_xrgb[0], row_xbgr[2]); /* B byte */
+	KUNIT_EXPECT_EQ(test, row_xrgb[3], (u8)9);
+	KUNIT_EXPECT_EQ(test, row_xbgr[3], (u8)9);
+}
+
+static struct kunit_case evdi_color_test_cases[] = {
+	KUNIT_CASE(test_identity_is_noop),
+	KUNIT_CASE(test_gamma_lut_applied_per_channel),
+	KUNIT_CASE(test_ctm_swaps_channels),
+	KUNIT_CASE(test_swap_rb_targets_correct_bytes),
+	{}
+};
+
+static struct kunit_suite evdi_color_test_suite = {
+	.name = "drm_evdi_color_tests",
+	.test_cases = evdi_color_test_cases,
+};
+
+kunit_test_suite(evdi_color_test_suite);
+
+MODULE_LICENSE("GPL");

--- a/module/tests/test_evdi_color.c
+++ b/module/tests/test_evdi_color.c
@@ -29,22 +29,29 @@ static void test_identity_is_noop(struct kunit *test)
 static void test_gamma_lut_applied_per_channel(struct kunit *test)
 {
 	struct evdi_color_data data = { 0 };
-	u8 row[4] = { 10, 20, 30, 0xAA }; /* B, G, R, X (XRGB8888 byte order) */
+	/* XRGB8888 is "x:R:G:B" MSB-to-LSB, little endian (drm_fourcc.h):
+	 * byte0=B=10, byte1=G=20, byte2=R=30, byte3=X=0xAA.
+	 */
+	u8 row[4] = { 10, 20, 30, 0xAA };
 	int i;
 
 	data.active = true;
 	data.has_gamma = true;
 	for (i = 0; i < EVDI_GAMMA_LUT_SIZE; ++i) {
-		data.gamma[0][i] = 255 - i; /* invert blue */
-		data.gamma[1][i] = i;       /* identity green */
-		data.gamma[2][i] = 0;       /* zero red */
+		data.gamma[0][i] = 255 - i; /* R: invert */
+		data.gamma[1][i] = i;       /* G: identity */
+		data.gamma[2][i] = 0;       /* B: zero */
 	}
 
 	evdi_color_transform_apply_row(&data, row, 1, false);
 
-	KUNIT_EXPECT_EQ(test, row[0], (u8)(255 - 10));
+	/* byte0 (true B, was 10) must go through the B curve (-> 0), not
+	 * the R curve - this is the exact split that would catch an R/B
+	 * byte-offset swap.
+	 */
+	KUNIT_EXPECT_EQ(test, row[0], (u8)0);
 	KUNIT_EXPECT_EQ(test, row[1], (u8)20);
-	KUNIT_EXPECT_EQ(test, row[2], (u8)0);
+	KUNIT_EXPECT_EQ(test, row[2], (u8)(255 - 30));
 	KUNIT_EXPECT_EQ(test, row[3], (u8)0xAA); /* X/alpha byte untouched */
 }
 


### PR DESCRIPTION
## Problem

evdi's virtual CRTC never calls `drm_crtc_enable_color_mgmt()`, so it
never exposes `GAMMA_LUT`/`CTM` DRM/KMS properties. Compositors that
apply color correction exclusively through those CRTC properties
(e.g. GNOME's Night Light) have nothing to set on an evdi output and
silently do nothing there, while native hardware CRTCs on the same
session are corrected normally.

## Fix

Since evdi has no real display hardware behind it, there's no
gamma/CTM block to program. This registers the properties (256-entry
gamma LUT, 3x3 CTM) via `drm_crtc_enable_color_mgmt()` in
`evdi_crtc_init()`, and applies the resulting transform in software in
`evdi_painter.c`'s `copy_primary_pixels()`/`copy_primary_pixels_on_xe()`
- the only place the driver has direct access to raw pixel bytes
before they're copied out to userspace via the `GRABPIX` ioctl.

- `evdi_color.c`/`.h`: self-contained transform (LUT + fixed-point CTM,
  built on `drm_fixed.h`'s S32.32 helpers), independent of whatever LUT
  length a client actually uploads.
- The transform is skipped entirely (identity fast path, zero added
  cost) unless a client has actually set a LUT or CTM - the common
  case is unaffected.
- `module/tests/test_evdi_color.c`: KUnit coverage of identity/gamma/
  CTM/channel-order behavior, no hardware required.

## Testing

- `ci/run_style_check` (checkpatch.pl): clean on all touched/new files.
- Built against a running 7.1.3 Fedora kernel's headers (`make
  KVER=...`), clean with `W=1`.
- Loaded on real hardware (DisplayLink dock + external monitor) and
  confirmed the CRTC now exposes `CTM`/`GAMMA_LUT`/`GAMMA_LUT_SIZE=256`
  via a direct `DRM_IOCTL_MODE_OBJ_GETPROPERTIES` query.

Note: on my own machine, GNOME's Night Light still doesn't visually
apply to this output in practice - but that traced back to an
unrelated GNOME/Mutter + colord monitor-identity collision (two
identical-model monitors whose EDID doesn't include a serial number),
not to anything in evdi. With a single monitor (or one with a real
EDID serial) behind the dock, this should work end-to-end.