### PR TITLE
modeset: Dirty the last cursor sprite on unassign

### DIFF
--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -385,6 +385,9 @@ static void evdi_cursor_atomic_update(struct drm_plane *plane,
 					rect = evdi_painter_framebuffer_size(evdi->painter);
 				}
 				evdi_painter_mark_dirty(evdi, &rect);
+			} else if (old_state && old_state->fb) {
+				evdi_cursor_atomic_get_rect(&old_rect, old_state);
+				evdi_painter_mark_dirty(evdi, &old_rect);
 			}
 			return;
 		}


### PR DESCRIPTION
On the software cursor path, disabling the plane does not dirty the last sprite, so the previous grab stays on the DisplayLink output until some other redraw. 
This only changes the unassign case. Motion and the cursor-events path are untouched.

Tried with mutter 50.4 and evdi 1.15 on a DisplayLink panel next to the laptop; leftover gone after the extra dirty. No kunit for this path.

Closes #588