### PR TITLE
Restore the painter pipeline when a reconnect arrives without a modeset

### DIFF
--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -47,6 +47,7 @@ struct evdi_painter;
 struct evdi_device {
 	struct drm_device *ddev;
 	struct drm_connector *conn;
+	struct drm_crtc *crtc;
 	struct evdi_cursor *cursor;
 	bool cursor_events_enabled;
 

--- a/module/evdi_drm_drv.h
+++ b/module/evdi_drm_drv.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only
  * Copyright (C) 2012 Red Hat
- * Copyright (c) 2015 - 2020 DisplayLink (UK) Ltd.
+ * Copyright (c) 2015 - 2026 DisplayLink (UK) Ltd.
  *
  * Based on parts on udlfb.c:
  * Copyright (C) 2009 its respective authors

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (C) 2012 Red Hat
- * Copyright (c) 2015 - 2020 DisplayLink (UK) Ltd.
+ * Copyright (c) 2015 - 2026 DisplayLink (UK) Ltd.
  *
  * Based on parts on udlfb.c:
  * Copyright (C) 2009 its respective authors

--- a/module/evdi_modeset.c
+++ b/module/evdi_modeset.c
@@ -472,6 +472,7 @@ static struct drm_plane *evdi_create_plane(
 
 static int evdi_crtc_init(struct drm_device *dev)
 {
+	struct evdi_device *evdi = dev->dev_private;
 	struct drm_crtc *crtc = NULL;
 	struct drm_plane *primary_plane = NULL;
 	struct drm_plane *cursor_plane = NULL;
@@ -502,6 +503,9 @@ static int evdi_crtc_init(struct drm_device *dev)
 
 	EVDI_DEBUG("drm_crtc_init: %d p%p\n", status, primary_plane);
 	drm_crtc_helper_add(crtc, &evdi_helper_funcs);
+
+	if (!status)
+		evdi->crtc = crtc;
 
 	return 0;
 }

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -913,6 +913,71 @@ static void evdi_remove_i2c_adapter(struct evdi_device *evdi)
 	}
 }
 
+/*
+ * A replug that completes within the compositor's hotplug hysteresis (3s in
+ * mutter) is coalesced away, so no atomic commit follows the reconnect and the
+ * painter - whose scanout buffer was dropped on disconnect - never starts
+ * producing frames again. The KMS pipeline itself was never torn down, so
+ * re-emit from the live crtc/plane state what a commit would have emitted.
+ */
+static void evdi_painter_replay_kms_state(struct evdi_device *evdi)
+{
+	struct evdi_painter *painter = evdi->painter;
+	struct drm_crtc *crtc = evdi->crtc;
+	struct drm_plane *primary = crtc ? crtc->primary : NULL;
+	struct drm_modeset_acquire_ctx ctx;
+	struct evdi_framebuffer *efb = NULL;
+	struct drm_display_mode mode = { 0 };
+	struct drm_clip_rect rect;
+	int ret;
+
+	if (!primary)
+		return;
+
+	drm_modeset_acquire_init(&ctx, 0);
+retry:
+	ret = drm_modeset_lock(&crtc->mutex, &ctx);
+	if (!ret)
+		ret = drm_modeset_lock(&primary->mutex, &ctx);
+
+	if (ret == -EDEADLK) {
+		ret = drm_modeset_backoff(&ctx);
+		if (!ret)
+			goto retry;
+	}
+
+	if (!ret &&
+	    crtc->state && crtc->state->active &&
+	    primary->state && primary->state->fb &&
+	    primary->state->crtc == crtc) {
+		efb = to_evdi_fb(primary->state->fb);
+		drm_framebuffer_get(&efb->base);
+		mode = crtc->state->adjusted_mode;
+	}
+
+	drm_modeset_drop_locks(&ctx);
+	drm_modeset_acquire_fini(&ctx);
+
+	if (!efb)
+		return;
+
+	EVDI_INFO("(card%d) Reconnected without modeset, replaying %dx%d@%d\n",
+		  evdi->dev_index, mode.hdisplay, mode.vdisplay,
+		  drm_mode_vrefresh(&mode));
+
+	evdi_painter_set_scanout_buffer(painter, efb);
+	evdi_painter_mode_changed_notify(evdi, &mode);
+	/* Keep it armed so a commit still in flight notifies again. */
+	evdi_painter_force_full_modeset(painter);
+	evdi_painter_dpms_notify(painter, DRM_MODE_DPMS_ON);
+
+	rect = evdi_painter_framebuffer_size(painter);
+	evdi_painter_mark_dirty(evdi, &rect);
+	evdi_painter_send_update_ready_if_needed(painter);
+
+	drm_framebuffer_put(&efb->base);
+}
+
 static int
 evdi_painter_connect(struct evdi_device *evdi,
 		     void const __user *edid_data, unsigned int edid_length,
@@ -922,6 +987,7 @@ evdi_painter_connect(struct evdi_device *evdi,
 {
 	struct evdi_painter *painter = evdi->painter;
 	struct edid *new_edid = NULL;
+	bool was_connected;
 	char buf[100];
 
 	evdi_log_process(buf, sizeof(buf));
@@ -952,6 +1018,7 @@ evdi_painter_connect(struct evdi_device *evdi,
 
 	painter_lock(painter);
 
+	was_connected = painter->is_connected;
 	evdi->pixel_area_limit = pixel_area_limit;
 	evdi->pixel_per_second_limit = pixel_per_second_limit;
 	painter->drm_filp = file;
@@ -967,6 +1034,10 @@ evdi_painter_connect(struct evdi_device *evdi,
 	painter_unlock(painter);
 
 	EVDI_INFO("(card%d) Connected with %s\n", evdi->dev_index, buf);
+
+	/* A double connect keeps the painter armed, nothing to replay. */
+	if (!was_connected)
+		evdi_painter_replay_kms_state(evdi);
 
 	drm_helper_hpd_irq_event(evdi->ddev);
 

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (c) 2013 - 2020 DisplayLink (UK) Ltd.
+ * Copyright (c) 2013 - 2026 DisplayLink (UK) Ltd.
  *
  * This file is subject to the terms and conditions of the GNU General Public
  * License v2. See the file COPYING in the main directory of this archive for

--- a/module/evdi_painter.c
+++ b/module/evdi_painter.c
@@ -605,6 +605,7 @@ static void evdi_painter_send_mode_changed(
 	struct drm_pending_event *event = create_mode_changed_event(
 		current_mode, bits_per_pixel, pixel_format);
 
+	EVDI_TEST_HOOK(evdi_testhook_painter_send_mode_changed(current_mode));
 	evdi_painter_send_event(painter, event);
 }
 

--- a/module/tests/Makefile
+++ b/module/tests/Makefile
@@ -1,5 +1,5 @@
 
 ccflags-$(CONFIG_DRM_EVDI_KUNIT_TEST) += -I$(srctree)/drivers/gpu/drm/evdi
 
-obj-$(CONFIG_DRM_EVDI_KUNIT_TEST) += evdi_test.o test_evdi_vt_switch.o evdi_fake_user_client.o evdi_fake_compositor.o
+obj-$(CONFIG_DRM_EVDI_KUNIT_TEST) += evdi_test.o test_evdi_vt_switch.o test_evdi_hotplug.o evdi_fake_user_client.o evdi_fake_compositor.o
 

--- a/module/tests/evdi_fake_compositor.c
+++ b/module/tests/evdi_fake_compositor.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (c) 2024 DisplayLink (UK) Ltd.
+ * Copyright (c) 2024 - 2026 DisplayLink (UK) Ltd.
  *
  * This file is subject to the terms and conditions of the GNU General Public
  * License v2. See the file COPYING in the main directory of this archive for

--- a/module/tests/evdi_fake_compositor.c
+++ b/module/tests/evdi_fake_compositor.c
@@ -45,6 +45,8 @@ void evdi_fake_compositor_create(struct kunit *test)
 		.base = {
 			.format = drm_format_info(DRM_FORMAT_XRGB8888),
 			.pitches = { 4*640, 0, 0 },
+			.width = 640,
+			.height = 480,
 			},
 		.obj = NULL,
 		.active = true
@@ -55,18 +57,43 @@ void evdi_fake_compositor_create(struct kunit *test)
 	memcpy(&compositor_data->mode, &default_mode, sizeof(default_mode));
 }
 
+/* Stands in for the atomic commit a real compositor would have done. */
+static void fake_compositor_set_kms_state(struct drm_device *device,
+					  struct evdi_framebuffer *efb,
+					  struct drm_display_mode *mode)
+{
+	struct evdi_device *evdi = (struct evdi_device *)device->dev_private;
+	struct drm_crtc *crtc = evdi->crtc;
+	struct drm_plane *primary = crtc ? crtc->primary : NULL;
+
+	if (!crtc || !crtc->state || !primary || !primary->state)
+		return;
+
+	crtc->state->enable = efb != NULL;
+	crtc->state->active = efb != NULL;
+	primary->state->crtc = efb ? crtc : NULL;
+	primary->state->fb = efb ? &efb->base : NULL;
+
+	if (mode)
+		crtc->state->adjusted_mode = *mode;
+}
+
 void evdi_fake_compositor_connect(struct kunit *test, struct drm_device *device)
 {
 	struct kunit_resource *resource = kunit_find_named_resource(test, "fake_wayland");
 	struct evdi_fake_compositor_data *compositor_data = resource->data;
 	struct evdi_device *evdi = (struct evdi_device *)device->dev_private;
 
+	fake_compositor_set_kms_state(device, compositor_data->efb,
+				      &compositor_data->mode);
+
 	evdi_painter_set_scanout_buffer(evdi->painter, compositor_data->efb);
 	evdi_painter_mode_changed_notify(evdi, &compositor_data->mode);
 	evdi_painter_dpms_notify(evdi->painter, DRM_MODE_DPMS_ON);
 }
 
-void evdi_fake_compositor_disconnect(__maybe_unused struct kunit *test, __maybe_unused struct drm_device *device)
+void evdi_fake_compositor_disconnect(__maybe_unused struct kunit *test, struct drm_device *device)
 {
+	fake_compositor_set_kms_state(device, NULL, NULL);
 }
 

--- a/module/tests/evdi_test.c
+++ b/module/tests/evdi_test.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (c) 2024 DisplayLink (UK) Ltd.
+ * Copyright (c) 2024 - 2026 DisplayLink (UK) Ltd.
  *
  * This file is subject to the terms and conditions of the GNU General Public
  * License v2. See the file COPYING in the main directory of this archive for

--- a/module/tests/evdi_test.c
+++ b/module/tests/evdi_test.c
@@ -55,6 +55,15 @@ void evdi_testhook_painter_send_dpms(int mode)
 		base->hooks.painter_send_dpms(mode);
 }
 
+void evdi_testhook_painter_send_mode_changed(const struct drm_display_mode *mode)
+{
+	struct kunit *test = kunit_get_current_test();
+	struct evdi_test_data *base = test ? (struct evdi_test_data *)test->priv : NULL;
+
+	if (base && base->hooks.painter_send_mode_changed)
+		base->hooks.painter_send_mode_changed(mode);
+}
+
 void evdi_testhook_drm_device_destroyed(void)
 {
 	struct kunit *test = kunit_get_current_test();

--- a/module/tests/evdi_test.h
+++ b/module/tests/evdi_test.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only
  *
- * Copyright (c) 2024 DisplayLink (UK) Ltd.
+ * Copyright (c) 2024 - 2026 DisplayLink (UK) Ltd.
  *
  * This file is subject to the terms and conditions of the GNU General Public
  * License v2. See the file COPYING in the main directory of this archive for

--- a/module/tests/evdi_test.h
+++ b/module/tests/evdi_test.h
@@ -22,14 +22,18 @@
 
 #include <linux/completion.h>
 
+struct drm_display_mode;
+
 /* evdi hooks for kunit tests */
 void evdi_testhook_painter_vt_register(struct notifier_block *vt_notifier);
 void evdi_testhook_painter_send_dpms(int mode);
+void evdi_testhook_painter_send_mode_changed(const struct drm_display_mode *mode);
 void evdi_testhook_drm_device_destroyed(void);
 
 struct evdi_test_hooks {
 	void (*painter_vt_register)(struct notifier_block *vt_notifier);
 	void (*painter_send_dpms)(int mode);
+	void (*painter_send_mode_changed)(const struct drm_display_mode *mode);
 	void (*drm_device_destroyed)(void);
 };
 

--- a/module/tests/test_evdi_hotplug.c
+++ b/module/tests/test_evdi_hotplug.c
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) 2026 DisplayLink (UK) Ltd.
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file COPYING in the main directory of this archive for
+ * more details.
+ */
+
+
+#include <kunit/test.h>
+#include <kunit/test-bug.h>
+#include <kunit/device.h>
+#include "evdi_drm_drv.h"
+#include "tests/evdi_test.h"
+#include "tests/evdi_fake_user_client.h"
+#include "tests/evdi_fake_compositor.h"
+
+
+struct evdi_hotplug_test {
+	struct evdi_test_data base;
+	int dpms_mode;
+	int mode_changed_count;
+	int hdisplay;
+	int vdisplay;
+};
+#define to_evdi_hotplug_test(x) container_of(x, struct evdi_hotplug_test, base)
+
+static void testhook_painter_send_dpms(int mode)
+{
+	struct kunit *test = kunit_get_current_test();
+	struct evdi_hotplug_test *data = to_evdi_hotplug_test(test->priv);
+
+	data->dpms_mode = mode;
+}
+
+static void testhook_painter_send_mode_changed(const struct drm_display_mode *mode)
+{
+	struct kunit *test = kunit_get_current_test();
+	struct evdi_hotplug_test *data = to_evdi_hotplug_test(test->priv);
+
+	data->mode_changed_count++;
+	data->hdisplay = mode->hdisplay;
+	data->vdisplay = mode->vdisplay;
+}
+
+static int suite_test_hotplug_init(struct kunit *test)
+{
+	struct evdi_hotplug_test *data =
+		kunit_kzalloc(test, sizeof(struct evdi_hotplug_test), GFP_KERNEL);
+
+	evdi_test_data_init(test, &data->base);
+	data->base.hooks.painter_send_dpms = testhook_painter_send_dpms;
+	data->base.hooks.painter_send_mode_changed = testhook_painter_send_mode_changed;
+	data->base.dev = evdi_drm_device_create(data->base.parent);
+
+	evdi_fake_compositor_create(test);
+	evdi_fake_user_client_create(test);
+
+	evdi_fake_user_client_connect(test, data->base.dev);
+	evdi_fake_compositor_connect(test, data->base.dev);
+
+	return 0;
+}
+
+static void suite_test_hotplug_exit(struct kunit *test)
+{
+	struct evdi_hotplug_test *data = to_evdi_hotplug_test(test->priv);
+
+	evdi_fake_compositor_disconnect(test, data->base.dev);
+	evdi_fake_user_client_disconnect(test, data->base.dev);
+
+	if (data->base.dev) {
+		evdi_drm_device_remove(data->base.dev);
+		data->base.dev = NULL;
+	}
+
+	evdi_test_data_exit(test, &data->base);
+	kunit_kfree(test, test->priv);
+}
+
+static void test_evdi_painter_replays_mode_on_reconnect_without_modeset(struct kunit *test)
+{
+	struct evdi_hotplug_test *data = to_evdi_hotplug_test(test->priv);
+	struct evdi_device *evdi = (struct evdi_device *)data->base.dev->dev_private;
+	struct drm_clip_rect rect;
+
+	data->mode_changed_count = 0;
+	data->dpms_mode = DRM_MODE_DPMS_OFF;
+
+	/* Replug too quick for the compositor to tear the pipeline down. */
+	evdi_fake_user_client_disconnect(test, data->base.dev);
+	evdi_fake_user_client_connect(test, data->base.dev);
+
+	KUNIT_EXPECT_EQ(test, data->mode_changed_count, 1);
+	KUNIT_EXPECT_EQ(test, data->hdisplay, 640);
+	KUNIT_EXPECT_EQ(test, data->vdisplay, 480);
+	KUNIT_EXPECT_EQ(test, data->dpms_mode, DRM_MODE_DPMS_ON);
+	KUNIT_EXPECT_TRUE(test, evdi_painter_needs_full_modeset(evdi->painter));
+
+	rect = evdi_painter_framebuffer_size(evdi->painter);
+	KUNIT_EXPECT_EQ(test, rect.x2, 640);
+	KUNIT_EXPECT_EQ(test, rect.y2, 480);
+}
+
+static void test_evdi_painter_does_not_replay_mode_when_pipeline_was_torn_down(struct kunit *test)
+{
+	struct evdi_hotplug_test *data = to_evdi_hotplug_test(test->priv);
+	struct evdi_device *evdi = (struct evdi_device *)data->base.dev->dev_private;
+
+	data->mode_changed_count = 0;
+	data->dpms_mode = DRM_MODE_DPMS_OFF;
+
+	evdi_fake_compositor_disconnect(test, data->base.dev);
+	evdi_fake_user_client_disconnect(test, data->base.dev);
+	evdi_fake_user_client_connect(test, data->base.dev);
+
+	KUNIT_EXPECT_EQ(test, data->mode_changed_count, 0);
+	KUNIT_EXPECT_NE(test, data->dpms_mode, DRM_MODE_DPMS_ON);
+	KUNIT_EXPECT_TRUE(test, evdi_painter_needs_full_modeset(evdi->painter));
+}
+
+static struct kunit_case evdi_test_cases[] = {
+	KUNIT_CASE(test_evdi_painter_replays_mode_on_reconnect_without_modeset),
+	KUNIT_CASE(test_evdi_painter_does_not_replay_mode_when_pipeline_was_torn_down),
+	{}
+};
+
+static struct kunit_suite evdi_test_suite = {
+	.name = "drm_evdi_hotplug_tests",
+	.test_cases = evdi_test_cases,
+	.init = suite_test_hotplug_init,
+	.exit = suite_test_hotplug_exit,
+};
+
+kunit_test_suite(evdi_test_suite);


### PR DESCRIPTION
### Issue description

After a quick dock/monitor replug the DisplayLink screen stays black. Reproduced on Ubuntu 26.04, kernel 7.0.0-14, Wayland, GNOME 50.1. Not reproducible on Ubuntu 24.04 / GNOME 46, which points at compositor-side behaviour rather than a kernel regression.

evdi_painter_disconnect() releases painter->scanout_fb, but it deliberately does not touch the KMS pipeline — crtc->state->active and primary->state->fb belong to the compositor. The painter is only ever re-armed from evdi_plane_atomic_update() / evdi_crtc_atomic_flush(), i.e. only when an atomic commit arrives.

Mutter coalesces a disconnect followed by a reconnect inside its hotplug hysteresis into "nothing changed", so no commit follows the reconnect. The painter is left with no scanout buffer, produces no frames, and the display stays black until the user forces a mode change. Kernel logs show the connect completing normally with no subsequent Notifying mode changed, and the connectors remain enabled=enabled throughout — the pipeline was never torn down.

### Fix description

Fix introduced with Copilot help. 
On a genuine reconnect, read the live crtc/plane state back under the modeset locks and re-emit what a commit would have emitted: re-take the scanout buffer, notify mode changed and DPMS on, and mark the framebuffer dirty.

Details worth flagging for review:

The replay runs before drm_helper_hpd_irq_event(). Running it after lets the uevent kick a concurrent compositor commit, so a stale mode could be emitted after the real one. Replaying first means a genuine commit — which still sees needs_full_modeset == true — always wins.
needs_full_modeset is re-armed after evdi_painter_mode_changed_notify() clears it, so a commit still in flight re-notifies rather than being swallowed.
Skipped when the painter was already connected. DLM issues a double connect on the same drm_filp for every card on every plug; without the guard each hotplug would emit a redundant mode_changed and re-program the DL device.
Bails out when crtc->state->active is false or the plane has no fb, i.e. when the compositor really did tear the pipeline down and will issue its own commit. First-ever plug is therefore unaffected.
Only long-standing DRM APIs are used (drm_modeset_lock, drm_modeset_backoff, drm_framebuffer_get), so no new conftest probes are needed.

### Testing
run_style_check — clean
run_kunit — drm_evdi_hotplug_tests passes
./ci/build_against_kernel all — clean
Manually verified on Ubuntu 26.04 / kernel 7.0.0-14 / GNOME 50.1: repeated fast replug now recovers
Verified no regression on a normal (slow) plug cycle and on VT switch.