### PR TITLE
Fix conftest probes on kernels with allocation profiling

### DIFF
--- a/module/conftest.sh
+++ b/module/conftest.sh
@@ -32,6 +32,7 @@ requote() {
 	done
 }
 CFLAGS=$(requote "$@")
+CFLAGS="$CFLAGS '-DKBUILD_MODNAME=\"conftest\"' '-DKBUILD_BASENAME=\"conftest\"'"
 
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT


### PR DESCRIPTION
v1.15.0 fails to build on kernels with `CONFIG_MEM_ALLOC_PROFILING=y`:

```
include/linux/acpi.h:69:50: error: macro 'kzalloc_obj' requires 2 arguments, but only 1 given
```

That's evdi's fallback `kzalloc_obj` from `evdi_debug.h` shadowing the kernel's
own macro, on a kernel that provides it. The support is in place
(`EVDI_HAVE_KZALLOC_OBJ`); detection is what fails.

`conftest.sh` compiles probes with `$(NOSTDINC_FLAGS) $(LINUXINCLUDE)
$(KBUILD_CPPFLAGS) $(KBUILD_CFLAGS) -DMODULE`, but `KBUILD_MODNAME` is a
per-object define kbuild adds outside `KBUILD_CFLAGS`, so probes never see it.
Since the probes define `MODULE`, and with allocation profiling on, every
allocator expands through `alloc_hooks` → `DEFINE_ALLOC_TAG` → `CT_MODULE_NAME`,
which `codetag.h` defines as `KBUILD_MODNAME` under `#ifdef MODULE`:

```
include/linux/codetag.h:64:24: error: 'KBUILD_MODNAME' undeclared
```

Any probe touching an allocator then fails regardless of whether the API
exists, and `evdi_detect.h` reports `EVDI_HAVE_KZALLOC_OBJ` unset on a kernel
that has it. Kernels without allocation profiling are unaffected —
`DEFINE_ALLOC_TAG` is empty there — which likely explains why CI stayed green.

Giving the probes a module name is enough:

```diff
 CFLAGS=$(requote "$@")
+CFLAGS="$CFLAGS '-DKBUILD_MODNAME=\"conftest\"' '-DKBUILD_BASENAME=\"conftest\"'"
```

This is not tied to one kernel release: I reproduced the failure and the fix on
both Linux 7.1.8 and 7.2.0 (CachyOS x86-64-v3, `CONFIG_MEM_ALLOC_PROFILING=y`,
gcc 15.3). Unpatched, both fail at `acpi.h:69`; patched, both build `evdi.ko`.
Compiling the probe body standalone shows the same split — it fails only with
`-DMODULE` and no `KBUILD_MODNAME`, and a probe without an allocation compiles
either way.

v1.14.x is unaffected: `conftest.sh` arrived with 490e1e8, released in v1.15.0.

(Disclosure: diagnosed and tested with Claude Code — Claude Fable 5 for the
first analysis, Claude Opus 5 for the verification and this text. I reviewed
the reasoning and ran the builds.)
